### PR TITLE
SoraLoggerはobject classとして定義してしまって大丈夫です

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/SoraLogger.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/SoraLogger.kt
@@ -8,41 +8,37 @@ import android.util.Log
  * cf.
  * - `android.util.Log`
  */
-class SoraLogger {
+object SoraLogger {
+    var enabled = false
+    var libjingle_enabled = false
 
-    companion object {
-        var enabled = false
-        var libjingle_enabled = false
-
-        fun v(tag: String?, msg: String) {
-            if (enabled) {
-                Log.v(tag, msg)
-            }
+    fun v(tag: String?, msg: String) {
+        if (enabled) {
+            Log.v(tag, msg)
         }
+    }
 
-        fun d(tag: String?, msg: String) {
-            if (enabled) {
-                Log.d(tag, msg)
-            }
+    fun d(tag: String?, msg: String) {
+        if (enabled) {
+            Log.d(tag, msg)
         }
+    }
 
-        fun i(tag: String?, msg: String) {
-            if (enabled) {
-                Log.i(tag, msg)
-            }
+    fun i(tag: String?, msg: String) {
+        if (enabled) {
+            Log.i(tag, msg)
         }
+    }
 
-        fun w(tag: String?, msg: String) {
-            if (enabled) {
-                Log.w(tag, msg)
-            }
+    fun w(tag: String?, msg: String) {
+        if (enabled) {
+            Log.w(tag, msg)
         }
+    }
 
-        fun e(tag: String?, msg: String) {
-            if (enabled) {
-                Log.e(tag, msg)
-            }
+    fun e(tag: String?, msg: String) {
+        if (enabled) {
+            Log.e(tag, msg)
         }
     }
 }
-


### PR DESCRIPTION
# 概要
`SoraLogger` をobject classにします。
companion objectでも良いのですが、object classにした方がネストが一段減らせるので。