### PR TITLE
multi module を利用する方法の説明を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ sora-android-sdk と sora-android-sdk-samples が同じディレクトリ以下�
 $ echo '../sora-android-sdk-samples' > include_app_dir.txt
 ```
 
-2. (optional) top level か samples の build.gradle に ext の設定を足す::
+2. (optional) settings.gradle に設定を足す
 
 ```
-     ext.signaling_endpoint = "wss://sora.example.com/signaling"
+signaling_endpoint=wss://sora.example.com/signaling
+channel_id=sora
 ```
 
 ## ローカルの libwebrtc.aar を参照する

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sora-android-sdk と sora-android-sdk-samples が同じディレクトリ以下�
 $ echo '../sora-android-sdk-samples' > include_app_dir.txt
 ```
 
-2. (optional) top level の settings.gradle に設定を足す
+2. (optional) top level の gradle.properties に設定を足す
 
 ```
 signaling_endpoint=wss://sora.example.com/signaling

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sora-android-sdk と sora-android-sdk-samples が同じディレクトリ以下�
 $ echo '../sora-android-sdk-samples' > include_app_dir.txt
 ```
 
-2. (optional) settings.gradle に設定を足す
+2. (optional) top level の settings.gradle に設定を足す
 
 ```
 signaling_endpoint=wss://sora.example.com/signaling


### PR DESCRIPTION
## 変更内容

- README.md 内の、 multi module を利用する方法の説明を更新しました
  - build.gradle ではなく、gradle.properties に記述する方が望ましい
  - sora-android-sdk-samples をビルドするには、 signaling_endpoint と channel_id の設定を追加する必要がある