### PR TITLE
スポットライト・レガシーが有効な場合は、サイマルキャストを有効にしない

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -1,5 +1,6 @@
 package jp.shiguredo.sora.sdk.channel.option
 
+import jp.shiguredo.sora.sdk.Sora
 import jp.shiguredo.sora.sdk.channel.signaling.message.SimulcastRid
 import jp.shiguredo.sora.sdk.codec.SimulcastVideoEncoderFactoryWrapper
 import org.webrtc.*
@@ -94,7 +95,10 @@ class SoraMediaOption {
     fun enableSpotlight(option: SoraSpotlightOption, eglContext: EglBase.Context) {
         spotlightOption = option
         multistreamEnabled = true
-        enableSimulcast(option.simulcastRid, eglContext)
+
+        if (!Sora.usesSpotlightLegacy) {
+            enableSimulcast(option.simulcastRid, eglContext)
+        }
     }
 
     /**


### PR DESCRIPTION
## 変更内容

- スポットライト・レガシーが動作しなくなっていたため修正しました

## 相談したい内容

- enableSpotlight に eglContext を渡していますが、スポットライト・レガシーが有効な場合は eglContext が不要になります。 enableSpotlight の中で enableSimulcast を呼び出す仕様も含めて、見直しても良いかもしれません。