### PR TITLE
依存ライブラリのアップデート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     repositories {
         jcenter()
         google()
+        gradlePluginPortal()
     }
 
     dependencies {
@@ -20,7 +21,7 @@ buildscript {
         classpath 'org.ajoberstar.grgit:grgit-gradle:3.1.1'
 
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
-        classpath 'org.ajoberstar.grgit:grgit-gradle:3.1.1'
+        classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
 
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'org.jetbrains.dokka'
 
 group = 'com.github.shiguredo'
@@ -75,11 +74,11 @@ dependencies {
 
     // required by "signaling" part
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
 
     // required by "rtc" part
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## 変更内容

- 依存ライブラリのバージョンを上げました
  - multi module として追加したsora-android-sdk-samples のビルドが通ることを確認しました
  
 作業後の `./gradlew dependencyUpdates` の結果は以下の通りです
 
 ```
 $ ./gradlew dependencyUpdates

> Task :dependencyUpdates
dependencyUpdates.resolutionStrategy: Remove the assignment operator, '=', when setting this task property

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - androidx.test:core:1.3.0
 - com.android.tools.build:gradle:4.1.2
 - com.github.ben-manes:gradle-versions-plugin:0.38.0
 - com.github.dcendents:android-maven-gradle-plugin:2.1
 - com.github.shiguredo:shiguredo-webrtc-android:89.4389.5.6
 - com.google.code.gson:gson:2.8.6
 - com.squareup.okhttp3:okhttp:4.9.1
 - io.reactivex.rxjava2:rxandroid:2.1.1
 - io.reactivex.rxjava2:rxjava:2.2.21
 - io.reactivex.rxjava2:rxkotlin:2.4.0
 - junit:junit:4.13.2
 - org.ajoberstar.grgit:grgit-gradle:4.1.0
 - org.robolectric:robolectric:4.5.1

The following dependencies have later milestone versions:
 - org.jetbrains.dokka:dokka-gradle-plugin [1.4.0-rc -> 1.4.10]
 - org.jetbrains.kotlin:kotlin-gradle-plugin [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-test-junit [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/

Failed to determine the latest version for the following dependencies (use --info for details):
 - org.jetbrains.kotlin:kotlin-reflect
     1.5.0-M1
 - org.jetbrains.kotlin:kotlin-stdlib
     1.5.0-M1

Gradle release-candidate updates:
 - Gradle: [6.8.3: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL in 4s
1 actionable task: 1 executed
 ```