### PR TITLE
Dokka を 1.4.20 に上げる

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.kotlin_version = '1.4.31'
     ext.libwebrtc_version = '89.4389.5.6'
 
-    ext.dokka_version = '1.4.0-rc'
+    ext.dokka_version = '1.4.20'
 
     repositories {
         jcenter()

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -46,21 +46,19 @@ android {
     }
 }
 
-dokkaHtml {
-    outputDirectory = "$buildDir/dokka"
-    disableAutoconfiguration = false
-    cacheRoot = file("default")
+dokkaHtml.configure {
+    outputDirectory.set(file("$buildDir/dokka"))
 
     dokkaSourceSets {
         configureEach {
-            moduleDisplayName = 'Sora Android SDK'
-            reportUndocumented = true
-            includes = ['packages.md']
+            moduleName = 'Sora Android SDK'
+            reportUndocumented.set(true)
+            includes.from(files(['packages.md']))
 
             sourceLink {
-                path = "sora-android-sdk/src/main/kotlin"
-                url = "https://github.com/shiguredo/sora-android-sdk/tree/master/sora-android-sdk/src/main/kotlin"
-                lineSuffix = "#L"
+                localDirectory.set(file("sora-android-sdk/src/main/kotlin"))
+                remoteUrl.set(uri("https://github.com/shiguredo/sora-android-sdk/tree/master/sora-android-sdk/src/main/kotlin").toURL())
+                remoteLineSuffix.set("#L")
             }
         }
     }


### PR DESCRIPTION
Dokka を 1.4.20 に上げて設定を修正しました。

- ドキュメントの生成は、 Android Studio の Gradle ツールウィンドウから sora-android-sdk > Tasks > documentation > dokkaHtml を実行します。
-  `sora-android-sdk/build/dokka` 以下に HTML ファイルが生成されます。
-  `navigation.html` をブラウザで開くと API リファレンスを参照できます。