### PR TITLE
SoraMediaChannel のメンバーを private に戻す (peer/signaling/getStatsTimer)

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -69,7 +69,7 @@ class SoraMediaChannel @JvmOverloads constructor(
      */
     val role = mediaOption.requiredRole
 
-    var getStatsTimer: Timer? = null
+    private var getStatsTimer: Timer? = null
 
     /**
      * [SoraMediaChannel] からコールバックイベントを受けるリスナー
@@ -232,8 +232,8 @@ class SoraMediaChannel @JvmOverloads constructor(
 
     }
 
-    var peer:            PeerChannel?      = null
-    var signaling:       SignalingChannel? = null
+    private var peer:            PeerChannel?      = null
+    private var signaling:       SignalingChannel? = null
 
     private var closing = false
 


### PR DESCRIPTION
## 変更内容

- SDK2 のリリース延期に伴い、 public にされたメンバーを private に戻します

## 動作確認

- sora-android-sdk-samples がビルドして Sora に接続出来ることを確認しました