### PR TITLE
NotificationMessage に漏れていたフィールドを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,8 +39,21 @@
     - @szktty
 - [UPDATE] `SoraMediaChannel.connectionId` を追加する
     - @szktty
+- [UPDATE] 廃止予定のプロパティに Deprecated アノテーションを追加する
+  - ChannelAttendeesCount.numberOfUpstreams
+  - ChannelAttendeesCount.numberOfDownstreams
+  - NotificationMessage.numberOfUpstreamConnections
+  - NotificationMessage.numberOfDownstreamConnections
+  - @enm10k
 - [FIX] スポットライトレガシーに対応する
     - @szktty
+- [FIX] NotificationMessage に漏れていた以下のフィールドを追加する
+    - authn_metadata
+    - authz_metadata
+    - channel_sendrecv_connections
+    - channel_sendonly_connections
+    - channel_recvonly_connections
+    - @enm10k
 
 ## 2020.3
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -277,8 +277,11 @@ class SoraMediaChannel @JvmOverloads constructor(
             when (notification.eventType) {
                 "connection.created", "connection.destroyed" -> {
                     val attendees = ChannelAttendeesCount(
-                            numberOfDownstreams = notification.numberOfDownstreamConnections!!,
-                            numberOfUpstreams = notification.numberOfUpstreamConnections!!
+                            numberOfDownstreams = notification.numberOfDownstreamConnections?: 0,
+                            numberOfUpstreams = notification.numberOfUpstreamConnections?: 0,
+                            numberOfSendrecv = notification.numberOfSendrecvConnections!!,
+                            numberOfSendonly = notification.numberOfSendonlyConnections!!,
+                            numberOfRecvonly = notification.numberOfRecvonlyConnections!!,
                     )
                     listener?.onAttendeesCountUpdated(this@SoraMediaChannel, attendees)
                 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -279,9 +279,9 @@ class SoraMediaChannel @JvmOverloads constructor(
                     val attendees = ChannelAttendeesCount(
                             numberOfDownstreams = notification.numberOfDownstreamConnections?: 0,
                             numberOfUpstreams = notification.numberOfUpstreamConnections?: 0,
-                            numberOfSendrecv = notification.numberOfSendrecvConnections!!,
-                            numberOfSendonly = notification.numberOfSendonlyConnections!!,
-                            numberOfRecvonly = notification.numberOfRecvonlyConnections!!,
+                            numberOfSendrecvConnections = notification.numberOfSendrecvConnections!!,
+                            numberOfSendonlyConnections = notification.numberOfSendonlyConnections!!,
+                            numberOfRecvonlyConnections = notification.numberOfRecvonlyConnections!!,
                     )
                     listener?.onAttendeesCountUpdated(this@SoraMediaChannel, attendees)
                 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
@@ -7,13 +7,13 @@ data class ChannelAttendeesCount(
         /**
          * 配信者数
          */
-        @Deprecated("numberOfUpstreams は2021 年 6 月リリース予定の Sora にて廃止されます。")
+        @Deprecated("numberOfUpstreams は 2021 年 6 月リリース予定の Sora にて廃止されます。")
         val numberOfUpstreams: Int,
 
         /**
          * 視聴者数
          */
-        @Deprecated("numberOfDownstreams は2021 年 6 月リリース予定の Sora にて廃止されます。")
+        @Deprecated("numberOfDownstreams は 2021 年 6 月リリース予定の Sora にて廃止されます。")
         val numberOfDownstreams: Int,
 
         /**

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
@@ -19,22 +19,22 @@ data class ChannelAttendeesCount(
         /**
          * sendrecv の接続数
          */
-        val numberOfSendrecv: Int,
+        val numberOfSendrecvConnections: Int,
 
         /**
          * sendonly の接続数
          */
-        val numberOfSendonly: Int,
+        val numberOfSendonlyConnections: Int,
 
         /**
          * recvonly の接続数
          */
-        val numberOfRecvonly: Int,
+        val numberOfRecvonlyConnections: Int,
 
         ) {
    /**
     * 配信者数と視聴者数の合計
     */
     val numberOfConnections: Int
-        get() = numberOfSendrecv + numberOfSendonly + numberOfRecvonly
+        get() = numberOfSendrecvConnections + numberOfSendonlyConnections + numberOfRecvonlyConnections
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
@@ -7,16 +7,34 @@ data class ChannelAttendeesCount(
         /**
          * 配信者数
          */
+        @Deprecated("numberOfUpstreams は2021 年 6 月リリース予定の Sora にて廃止されます。")
         val numberOfUpstreams: Int,
 
         /**
          * 視聴者数
          */
-        val numberOfDownstreams: Int
-) {
+        @Deprecated("numberOfDownstreams は2021 年 6 月リリース予定の Sora にて廃止されます。")
+        val numberOfDownstreams: Int,
+
+        /**
+         * sendrecv の接続数
+         */
+        val numberOfSendrecv: Int,
+
+        /**
+         * sendonly の接続数
+         */
+        val numberOfSendonly: Int,
+
+        /**
+         * recvonly の接続数
+         */
+        val numberOfRecvonly: Int,
+
+        ) {
    /**
     * 配信者数と視聴者数の合計
     */
     val numberOfConnections: Int
-        get() = numberOfUpstreams + numberOfDownstreams
+        get() = numberOfSendrecv + numberOfSendonly + numberOfRecvonly
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -157,7 +157,9 @@ data class NotificationMessage(
         @SerializedName("metadata_list")                  val metadataList:                  Any?,
         @SerializedName("minutes")                        val connectionTime:                Long?,
         @SerializedName("channel_connections")            val numberOfConnections:           Int?,
+        @Deprecated("numberOfUpstreamConnections は2021 年 6 月リリース予定の Sora にて廃止されます。")
         @SerializedName("channel_upstream_connections")   val numberOfUpstreamConnections:   Int?,
+        @Deprecated("numberOfDownstreamConnections は2021 年 6 月リリース予定の Sora にて廃止されます。")
         @SerializedName("channel_downstream_connections") val numberOfDownstreamConnections: Int?,
         @SerializedName("channel_sendrecv_connections")   val numberOfSendrecvConnections:   Int?,
         @SerializedName("channel_sendonly_connections")   val numberOfSendonlyConnections:   Int?,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -167,6 +167,6 @@ data class NotificationMessage(
         @SerializedName("spotlight_id")                   val spotlightId:                   String?,
         @SerializedName("fixed")                          val fixed:                         Boolean?,
         @SerializedName("authn_metadata")                 val authnMetadata:                 Any?,
-        @SerializedName("authz_metadata")                 val AuthzMetadata:                 Any?,
+        @SerializedName("authz_metadata")                 val authzMetadata:                 Any?,
 ) {
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -157,9 +157,9 @@ data class NotificationMessage(
         @SerializedName("metadata_list")                  val metadataList:                  Any?,
         @SerializedName("minutes")                        val connectionTime:                Long?,
         @SerializedName("channel_connections")            val numberOfConnections:           Int?,
-        @Deprecated("numberOfUpstreamConnections は2021 年 6 月リリース予定の Sora にて廃止されます。")
+        @Deprecated("numberOfUpstreamConnections は 2021 年 6 月リリース予定の Sora にて廃止されます。")
         @SerializedName("channel_upstream_connections")   val numberOfUpstreamConnections:   Int?,
-        @Deprecated("numberOfDownstreamConnections は2021 年 6 月リリース予定の Sora にて廃止されます。")
+        @Deprecated("numberOfDownstreamConnections は 2021 年 6 月リリース予定の Sora にて廃止されます。")
         @SerializedName("channel_downstream_connections") val numberOfDownstreamConnections: Int?,
         @SerializedName("channel_sendrecv_connections")   val numberOfSendrecvConnections:   Int?,
         @SerializedName("channel_sendonly_connections")   val numberOfSendonlyConnections:   Int?,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -159,8 +159,14 @@ data class NotificationMessage(
         @SerializedName("channel_connections")            val numberOfConnections:           Int?,
         @SerializedName("channel_upstream_connections")   val numberOfUpstreamConnections:   Int?,
         @SerializedName("channel_downstream_connections") val numberOfDownstreamConnections: Int?,
+        @SerializedName("channel_sendrecv_connections")   val numberOfSendrecvConnections:   Int?,
+        @SerializedName("channel_sendonly_connections")   val numberOfSendonlyConnections:   Int?,
+        @SerializedName("channel_recvonly_connections")   val numberOfRecvonlyConnections:   Int?,
         @SerializedName("unstable_level")                 val unstableLevel:                 Int?,
         @SerializedName("channel_id")                     val channelId:                     String?,
         @SerializedName("spotlight_id")                   val spotlightId:                   String?,
-        @SerializedName("fixed")                          val fixed:                         Boolean?
-)
+        @SerializedName("fixed")                          val fixed:                         Boolean?,
+        @SerializedName("authn_metadata")                 val authnMetadata:                 Any?,
+        @SerializedName("authz_metadata")                 val AuthzMetadata:                 Any?,
+) {
+}


### PR DESCRIPTION
## 変更内容

- NotificationMessage に漏れていた以下のフィールドを追加しました
  - authn_metadata
  - authz_metadata
  - channel_sendrecv_connections
  - channel_sendonly_connections
  - channel_recvonly_connections
- ChannelAttendeesCount の numberOfUpstreams, numberOfDownstreams に Deprecated アノテーションを追加しました

## 動作確認

- [ ] authn_metadata / authz_metadata
  -> develop ブランチにマージ後に行う
- [x] channel_sendrecv_connections / channel_sendonly_connections / channel_recvonly_connections
  -  Kotlin の ChannelAttendeesCount に反映されていることを Logcat で確認

```
# channel_sendrecv_connections / channel_sendonly_connections / channel_recvonly_connections の挙動を Logcat で確認したメモ
2021-03-17 13:43:16.219 7328-8474/jp.shiguredo.sora.sample D/SoraVideoChannel: [video_channel] @onNotificationmessage connection.created NotificationMessage(type=notify, eventType=connection.created, ... numberOfConnections=3, numberOfUpstreamConnections=2, numberOfDownstreamConnections=1, numberOfSendrecvConnections=1, numberOfSendonlyConnections=1, numberOfRecvonlyConnections=1, ...)
```

## 残りタスク

- [x] CHANGES.md の更新