### PR TITLE
Sora 2020.1 で PCMU がサポート対象外となったので、 SoraAudioOption.Codec から削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 
 ## develop
 
-- [CHANGE] 
-  - @s
+- [CHANGE] SoraAudioOption.Codec から PCMU を外す
+    - @enm10k
 - [UPDATE] libwebrtc を 89.4389.5.6 に上げる
     - @enm10k
 - [UPDATE] Kotlin を 1.4.31 に上げる

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
@@ -22,8 +22,6 @@ class SoraAudioOption {
     enum class Codec {
         /** Opus */
         OPUS,
-        /** PCMU */
-        PCMU
     }
 
     /**


### PR DESCRIPTION
## 変更内容

- Sora 2020.1 で PCMU がサポート対象外となったので、 SoraAudioOption.Codec から削除しました