### PR TITLE
NotificationMessage に data フィールドを追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,11 +45,16 @@
     - @szktty
 - [UPDATE] `SoraMediaChannel.connectionId` を追加する
     - @szktty
+- [UPDATE] `NotificationMessage.data` を追加する
+    - @enm10k
 - [UPDATE] 廃止予定のプロパティに Deprecated アノテーションを追加する
     - ChannelAttendeesCount.numberOfUpstreams
     - ChannelAttendeesCount.numberOfDownstreams
     - NotificationMessage.numberOfUpstreamConnections
     - NotificationMessage.numberOfDownstreamConnections
+    - @enm10k
+- [UPDATE] 変更予定のプロパティに Deprecated アノテーションを追加する
+    - NotificationMessage.metadataList -> NotificationMessage.data に変更予定
     - @enm10k
 - [FIX] スポットライトレガシーに対応する
     - スポットライトレガシーを利用する際は `Sora.usesSpotlightLegacy = true` を設定する必要があります

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -154,6 +154,7 @@ data class NotificationMessage(
         @SerializedName("audio")                          val audio:                         Boolean?,
         @SerializedName("video")                          val video:                         Boolean?,
         @SerializedName("metadata")                       val metadata:                      Any?,
+        @Deprecated("metadata_list は将来の Sora のリリースでフィールド名を data に変更する予定です。")
         @SerializedName("metadata_list")                  val metadataList:                  Any?,
         @SerializedName("minutes")                        val connectionTime:                Long?,
         @SerializedName("channel_connections")            val numberOfConnections:           Int?,
@@ -170,5 +171,6 @@ data class NotificationMessage(
         @SerializedName("fixed")                          val fixed:                         Boolean?,
         @SerializedName("authn_metadata")                 val authnMetadata:                 Any?,
         @SerializedName("authz_metadata")                 val authzMetadata:                 Any?,
+        @SerializedName("data")                           val data:                          Any?,
 ) {
 }


### PR DESCRIPTION
## 変更内容

- NotificationMessage に data フィールドを追加しました
- metadataList フィールドに Deprecated アノテーションを追加しました

## 動作確認

sora.conf で `signaling_notify_metadata_ext = true` を設定した上で、 https://sora-doc.shiguredo.jp/signaling_notify_metadata_ext#id10 の手順に従い Sora DEMO -> sora-android-sdk-samples の順に Sora 接続しました

sora-android-sdk-samples を Sora に接続したタイミングで、 data が受信できることを確認しています