### PR TITLE
libwebrtc を 89.4389.7.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [CHANGE] SoraAudioOption.Codec から PCMU を外す
     - @enm10k
-- [UPDATE] libwebrtc を 89.4389.5.6 に上げる
+- [UPDATE] libwebrtc を 89.4389.7.0 に上げる
     - @enm10k
 - [UPDATE] Kotlin を 1.4.31 に上げる
     - @szktty

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.4.31'
-    ext.libwebrtc_version = '89.4389.5.6'
+    ext.libwebrtc_version = '89.4389.7.0'
 
     ext.dokka_version = '0.10.1'
 


### PR DESCRIPTION
## 変更内容

- libwebrtc のバージョンをを 89.4389.7.0 に上げました