### PR TITLE
TextureBuffer が上がってきた時にスケールするレイヤを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,11 @@
     - @enm10k
 - [FIX] サイマルキャストのパラメーター active: false が無効化されてしまう問題を修正する
     - @enm10k
+- [FIX] サイマルキャストで TextureBuffer のエンコードに対応する
+    - TextureBuffer と HardwareVideoEncoder の場合にはスケーリング処理が simulcast_encoder_adapter で
+      行われないため、initEncode の情報を元にスケーリングを処理するレイヤを追加
+    - 同じレイヤでストリームごとにスレッドを起こし、そのスレッド上で内部エンコーダに移譲するように変更
+    - @shino
 
 ## 2020.3
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -78,14 +78,14 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
             if (streamSettings == null) {
                 return encoder.encode(frame, encodeInfo)
             }
-            val adaptedFrame = if (frame.buffer.width == streamSettings!!.width) {
-                frame
+            if (frame.buffer.width == streamSettings!!.width) {
+                return encoder.encode(frame, encodeInfo)
             } else {
                 val buffer = frame.buffer
-                val ratio = buffer.width / streamSettings!!.width
-                SoraLogger.d(TAG, "encode: Scaling needed, " +
-                        "${buffer.width}x${buffer.height} to ${streamSettings!!.width}x${streamSettings!!.height}, " +
-                        "ratio=$ratio")
+                // val ratio = buffer.width / streamSettings!!.width
+                // SoraLogger.d(TAG, "encode: Scaling needed, " +
+                //         "${buffer.width}x${buffer.height} to ${streamSettings!!.width}x${streamSettings!!.height}, " +
+                //         "ratio=$ratio")
                 // TODO(shino): へんなスケールファクタの場合に正しく動作するか?
                 // TODO(shino): I420 への変換は必要?
                 val i420Buffer = buffer.toI420()
@@ -93,9 +93,10 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
                         streamSettings!!.width, streamSettings!!.height)
                 i420Buffer.release()
                 val adaptedFrame = VideoFrame(adaptedBuffer, frame.rotation, frame.timestampNs)
-                adaptedFrame
+                val result = encoder.encode(adaptedFrame, encodeInfo)
+                adaptedBuffer.release()
+                return result
             }
-            return encoder.encode(adaptedFrame, encodeInfo)
         }
 
         override fun setRateAllocation(allocation: VideoEncoder.BitrateAllocation?, frameRate: Int): VideoCodecStatus {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -80,7 +80,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
             }
             val adaptedFrame = if (frame.buffer.width == streamSettings!!.width) {
                 frame
-            }else {
+            } else {
                 val buffer = frame.buffer
                 val ratio = buffer.width / streamSettings!!.width
                 SoraLogger.d(TAG, "encode: Scaling needed, " +
@@ -89,7 +89,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
                 // TODO(shino): へんなスケールファクタの場合に正しく動作するか?
                 // TODO(shino): I420 への変換は必要?
                 val adaptedBuffer = buffer.toI420().cropAndScale(0, 0, buffer.width, buffer.height,
-                        streamSettings!!.width, streamSettings!!.height / ratio)
+                        streamSettings!!.width, streamSettings!!.height)
                 val adaptedFrame = VideoFrame(adaptedBuffer, frame.rotation, frame.timestampNs)
                 adaptedFrame
             }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -2,7 +2,6 @@ package jp.shiguredo.sora.sdk.codec
 
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.*
-import java.util.*
 import java.util.concurrent.*
 
 internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Context?,
@@ -92,9 +91,9 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
                 // SoraLogger.d(TAG, "encode() buffer=${frame.buffer}, thread=${Thread.currentThread().name} "
                 //         + "[${Thread.currentThread().id}]")
                 if (streamSettings == null) {
-                    return@Callable encoder.encode(frame, encodeInfo) as VideoCodecStatus
+                    return@Callable encoder.encode(frame, encodeInfo)
                 } else if (frame.buffer.width == streamSettings!!.width) {
-                    return@Callable encoder.encode(frame, encodeInfo) as VideoCodecStatus
+                    return@Callable encoder.encode(frame, encodeInfo)
                 } else {
                     // 上がってきたバッファと initEncode() の設定が違うパターン、ここでスケールする必要がある
                     val originalBuffer = frame.buffer

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -88,8 +88,10 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
                         "ratio=$ratio")
                 // TODO(shino): へんなスケールファクタの場合に正しく動作するか?
                 // TODO(shino): I420 への変換は必要?
-                val adaptedBuffer = buffer.toI420().cropAndScale(0, 0, buffer.width, buffer.height,
+                val i420Buffer = buffer.toI420()
+                val adaptedBuffer = i420Buffer.cropAndScale(0, 0, buffer.width, buffer.height,
                         streamSettings!!.width, streamSettings!!.height)
+                i420Buffer.release()
                 val adaptedFrame = VideoFrame(adaptedBuffer, frame.rotation, frame.timestampNs)
                 adaptedFrame
             }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -89,7 +89,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(sharedContext: EglBase.Contex
 
         override fun encode(frame: VideoFrame, encodeInfo: VideoEncoder.EncodeInfo?): VideoCodecStatus {
             val future = executor.submit(Callable {
-                // SoraLogger.d(TAG, "encode() buffer=${frame.buffe}, thread=${Thread.currentThread().name} "
+                // SoraLogger.d(TAG, "encode() buffer=${frame.buffer}, thread=${Thread.currentThread().name} "
                 //         + "[${Thread.currentThread().id}]")
                 if (streamSettings == null) {
                     return@Callable encoder.encode(frame, encodeInfo) as VideoCodecStatus


### PR DESCRIPTION
変更点
- libwebrtc から encode() で渡ってきたバッファを cropAndScale する wrapper を挟む
- TextureBuffer が複数のエンコーダに渡る際におかしくなるので、ストリームごとにスレッドを上げて処理を投げる

解決した課題
- どの画面の向きでサイマルキャストしても、視聴側の映像が流れるようにはなった
- scaleResolutionDownBy=4/1/1 のばあい、 r1/r2 両方に同じ TextureBuffer が流れるが、両方が配信されるようになった

懸念点
- [x] (クリティカル) メモリリークしている
- [x]  I420 への変換は必要か
- [x] このこーどでいいのか