### PR TITLE
シグナリングの改善

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [CHANGE] ConnectMessage.channelId の型を String? から String に変更する
+  - @enm10k
+- [UPDATE] NotificationMessage に turnTransportType を追加する
+  - @enm10k
 - [ADD] データチャネルシグナリングに対応する
   - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
   - onDataChannel コールバックを実装する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,7 @@
 
 ## develop
 
-- [CHANGE] ConnectMessage.channelId の型を String? から String に変更する
-  - @enm10k
-- [UPDATE] NotificationMessage に turnTransportType を追加する
+- [CHANGE] SoraMediaChannel のコンストラクタ引数 channelId の型を String? から String に変更する
   - @enm10k
 - [ADD] データチャネルシグナリングに対応する
   - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
@@ -26,6 +24,8 @@
   - @shino
 - [FIX] offer に data_channels が含まれない場合に対応する
   - @shino
+- [FIX] NotificationMessage に turnTransportType を追加する
+  - @enm10k
 
 ## 2021.1
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -51,7 +51,7 @@ import kotlin.concurrent.schedule
 class SoraMediaChannel @JvmOverloads constructor(
         private val context:                   Context,
         private val signalingEndpoint:         String,
-        private val channelId:                 String?,
+        private val channelId:                 String,
         private val signalingMetadata:         Any?                 = "",
         private val mediaOption:               SoraMediaOption,
         private val timeoutSeconds:            Long                 = DEFAULT_TIMEOUT_SECONDS,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -38,7 +38,7 @@ interface SignalingChannel {
 class SignalingChannelImpl @JvmOverloads constructor(
         private val endpoint:                         String,
         private val role:                             SoraChannelRole,
-        private val channelId:                        String?,
+        private val channelId:                        String,
         private val connectDataChannelSignaling:      Boolean?                    = null,
         private val connectIgnoreDisconnectWebSocket: Boolean?                    = null,
         private val mediaOption:                      SoraMediaOption,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -22,7 +22,7 @@ data class PongMessage(
 data class ConnectMessage(
         @SerializedName("type")        val type:                      String = "connect",
         @SerializedName("role")        var role:                      String,
-        @SerializedName("channel_id")  val channelId:                 String?,
+        @SerializedName("channel_id")  val channelId:                 String,
         @SerializedName("client_id")   val clientId:                  String? = null,
         @SerializedName("metadata")    val metadata:                  Any? = null,
         @SerializedName("signaling_notify_metadata")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -193,6 +193,7 @@ data class NotificationMessage(
         @SerializedName("authn_metadata")                 val authnMetadata:                 Any?,
         @SerializedName("authz_metadata")                 val authzMetadata:                 Any?,
         @SerializedName("data")                           val data:                          Any?,
+        @SerializedName("turn_transport_type")            val turnTransportType:             String?,
 )
 
 data class DisconnectMessage(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -16,7 +16,7 @@ class MessageConverter {
 
         @JvmOverloads
         fun buildConnectMessage(role: SoraChannelRole,
-                                channelId: String?,
+                                channelId: String,
                                 dataChannelSignaling: Boolean?,
                                 ignoreDisconnectWebSocket: Boolean?,
                                 mediaOption: SoraMediaOption,


### PR DESCRIPTION
## 変更内容

- ConnectMessage.channelId の型を String? から String に変更しました
  - `channelId = ""` を指定すると、接続時に Sora からエラーが返却されます
  - SDK 側で文字列の長さをチェックしたりする処理は実装していません
- NotificationMessage に turnTransportType を追加する