### PR TITLE
[README] multi module で -samples を動かす手順の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,19 @@ JitPack 上でビルドされた AAR や POM、およびログは次のように
 
 sora-android-sdk と sora-android-sdk-samples が同じディレクトリ以下に clone されているとします。
 
-1.  `include_app_dir.txt` に sora-android-sdk-samples のディレクトリパスを書く
+1. `include_app_dir.txt` に sora-android-sdk-samples のディレクトリパスを書く
 
 ```
 $ echo '../sora-android-sdk-samples' > include_app_dir.txt
 ```
 
-2. (optional) top level の gradle.properties に設定を足す
+2. top level の gradle.properties に設定を足す
+
+```
+usesCleartextTraffic = false
+```
+
+3. (optional) top level の gradle.properties に設定を足す
 
 ```
 signaling_endpoint=wss://sora.example.com/signaling


### PR DESCRIPTION
※情報共有です。一定期間おいてマージをします。

sora-android-sdk-samples の 「gradle.properties の usesCleartextTraffic を参照する」の修正に対応して
https://github.com/shiguredo/sora-android-sdk-samples/commit/e354b67adc312629d85d80b2bf9b1fe703efd313
multi module で -samples を動かす手順に `usesCleartextTraffic` を設定する手順を追加しました。

余分な空白を削除するコスメも合わせて実施しています。
