### PR TITLE
mid に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   - @enm10k
 - [UPDATE] スポットライト接続時に spotlight_focus_rid / spotlight_unfocus_rid を指定できるようにする
   - @enm10k
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - `com.android.tools.build:gradle` を 4.2.2 に上げる
+  - @enm10k
 - [ADD] データチャネルシグナリングに対応する
   - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
   - onDataChannel コールバックを実装する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - @enm10k
 - [UPDATE] スポットライト接続時に spotlight_focus_rid / spotlight_unfocus_rid を指定できるようにする
   - @enm10k
+- [UPDATE] offer に mid が含まれる場合は、 mid を利用して sender を設定する
+  - @enm10k
 - [UPDATE] 依存ライブラリーのバージョンを上げる
   - `com.android.tools.build:gradle` を 4.2.2 に上げる
   - @enm10k

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -611,7 +611,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             }
         }
         peer?.run {
-            val subscription = handleInitialRemoteOffer(offerMessage.sdp, offerMessage.encodings)
+            val subscription = handleInitialRemoteOffer(offerMessage.sdp, offerMessage.mid, offerMessage.encodings)
                     .observeOn(Schedulers.io())
                     .subscribeBy(
                             onSuccess = {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -299,10 +299,10 @@ class PeerChannelImpl(
             val audioMid = mid?.get("audio")
             if (audioMid != null) {
                 mid?.get("audio")?.let { audioMid ->
-                    val transceiver =  this.conn?.transceivers!!.find { it.mid == audioMid }
-                    transceiver!!.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
+                    val transceiver =  this.conn?.transceivers?.find { it.mid == audioMid }
+                    transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                     SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
-                    audioSender = transceiver.sender
+                    audioSender = transceiver?.sender
 
                     localStream!!.audioTracks.firstOrNull()?.let {
                         SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
@@ -311,16 +311,16 @@ class PeerChannelImpl(
                 }
             } else {
                 audioSender = localStream!!.audioTracks.firstOrNull()?.let {
-                    conn!!.addTrack(it, mediaStreamLabels)
+                    conn?.addTrack(it, mediaStreamLabels)
                 }
             }
 
             val videoMid = mid?.get("video")
             if (videoMid != null) {
                 val transceiver = this.conn?.transceivers?.find { it.mid == videoMid }
-                transceiver!!.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
+                transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                 SoraLogger.d(TAG, "set video sender: mid=${mid}, transceiver=${transceiver} ")
-                videoSender = transceiver.sender
+                videoSender = transceiver?.sender
 
                 localStream!!.videoTracks.firstOrNull()?.let {
                     SoraLogger.d(TAG, "set video track: track=$it, enabled=${it.enabled()}")
@@ -328,7 +328,7 @@ class PeerChannelImpl(
                 }
             } else {
                 videoSender = localStream!!.videoTracks.firstOrNull()?.let {
-                    conn!!.addTrack(it, mediaStreamLabels)
+                    conn?.addTrack(it, mediaStreamLabels)
                 }
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -302,6 +302,7 @@ class PeerChannelImpl(
                 transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                 SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
                 audioSender = transceiver?.sender
+                audioSender?.streams = arrayOf(localStream!!.id).toMutableList()
 
                 localStream!!.audioTracks.firstOrNull()?.let {
                     SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
@@ -319,6 +320,7 @@ class PeerChannelImpl(
                 transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                 SoraLogger.d(TAG, "set video sender: mid=${mid}, transceiver=${transceiver} ")
                 videoSender = transceiver?.sender
+                videoSender?.streams = arrayOf(localStream!!.id).toMutableList()
 
                 localStream!!.videoTracks.firstOrNull()?.let {
                     SoraLogger.d(TAG, "set video track: track=$it, enabled=${it.enabled()}")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -302,7 +302,7 @@ class PeerChannelImpl(
                 transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                 SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
                 audioSender = transceiver?.sender
-                audioSender?.streams = arrayOf(localStream!!.id).toMutableList()
+                audioSender?.streams = listOf(localStream!!.id)
 
                 localStream!!.audioTracks.firstOrNull()?.let {
                     SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
@@ -320,7 +320,7 @@ class PeerChannelImpl(
                 transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
                 SoraLogger.d(TAG, "set video sender: mid=${mid}, transceiver=${transceiver} ")
                 videoSender = transceiver?.sender
-                videoSender?.streams = arrayOf(localStream!!.id).toMutableList()
+                videoSender?.streams = listOf(localStream!!.id)
 
                 localStream!!.videoTracks.firstOrNull()?.let {
                     SoraLogger.d(TAG, "set video track: track=$it, enabled=${it.enabled()}")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -298,16 +298,14 @@ class PeerChannelImpl(
 
             val audioMid = mid?.get("audio")
             if (audioMid != null) {
-                mid?.get("audio")?.let { audioMid ->
-                    val transceiver =  this.conn?.transceivers?.find { it.mid == audioMid }
-                    transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
-                    SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
-                    audioSender = transceiver?.sender
+                val transceiver =  this.conn?.transceivers?.find { it.mid == audioMid }
+                transceiver?.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
+                SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
+                audioSender = transceiver?.sender
 
-                    localStream!!.audioTracks.firstOrNull()?.let {
-                        SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
-                        audioSender?.setTrack(it, false)
-                    }
+                localStream!!.audioTracks.firstOrNull()?.let {
+                    SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
+                    audioSender?.setTrack(it, false)
                 }
             } else {
                 audioSender = localStream!!.audioTracks.firstOrNull()?.let {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -19,7 +19,9 @@ import java.util.zip.*
 
 interface PeerChannel {
 
-    fun handleInitialRemoteOffer(offer: String, encodings: List<Encoding>?): Single<SessionDescription>
+    fun handleInitialRemoteOffer(offer: String,
+                                 mid: Map<String, String>?,
+                                 encodings: List<Encoding>?): Single<SessionDescription>
     fun handleUpdatedRemoteOffer(offer: String): Single<SessionDescription>
 
     // 失敗しても問題のない処理が含まれる (client offer SDP は生成に失敗しても問題ない) ので、
@@ -278,7 +280,9 @@ class PeerChannelImpl(
         }
     }
 
-    override fun handleInitialRemoteOffer(offer: String, encodings: List<Encoding>?): Single<SessionDescription> {
+    override fun handleInitialRemoteOffer(offer: String,
+                                          mid: Map<String, String>?,
+                                          encodings: List<Encoding>?): Single<SessionDescription> {
 
         val offerSDP = SessionDescription(SessionDescription.Type.OFFER, offer)
         offerEncodings = encodings
@@ -292,11 +296,40 @@ class PeerChannelImpl(
             // https://bugs.chromium.org/p/chromium/issues/detail?id=944821
             val mediaStreamLabels = listOf(localStream!!.id)
 
-            audioSender = localStream!!.audioTracks.firstOrNull()?.let {
-                conn!!.addTrack(it, mediaStreamLabels)
+            val audioMid = mid?.get("audio")
+            if (audioMid != null) {
+                mid?.get("audio")?.let { audioMid ->
+                    val transceiver =  this.conn?.transceivers!!.find { it.mid == audioMid }
+                    transceiver!!.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
+                    SoraLogger.d(TAG, "set audio sender: mid=${audioMid}, transceiver=${transceiver}")
+                    audioSender = transceiver.sender
+
+                    localStream!!.audioTracks.firstOrNull()?.let {
+                        SoraLogger.d(TAG, "set audio track: track=$it, enabled=${it.enabled()}")
+                        audioSender?.setTrack(it, false)
+                    }
+                }
+            } else {
+                audioSender = localStream!!.audioTracks.firstOrNull()?.let {
+                    conn!!.addTrack(it, mediaStreamLabels)
+                }
             }
-            videoSender = localStream!!.videoTracks.firstOrNull()?.let {
-                conn!!.addTrack(it, mediaStreamLabels)
+
+            val videoMid = mid?.get("video")
+            if (videoMid != null) {
+                val transceiver = this.conn?.transceivers?.find { it.mid == videoMid }
+                transceiver!!.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
+                SoraLogger.d(TAG, "set video sender: mid=${mid}, transceiver=${transceiver} ")
+                videoSender = transceiver.sender
+
+                localStream!!.videoTracks.firstOrNull()?.let {
+                    SoraLogger.d(TAG, "set video track: track=$it, enabled=${it.enabled()}")
+                    videoSender?.setTrack(it, false)
+                }
+            } else {
+                videoSender = localStream!!.videoTracks.firstOrNull()?.let {
+                    conn!!.addTrack(it, mediaStreamLabels)
+                }
             }
 
             if (mediaOption.simulcastEnabled && mediaOption.videoUpstreamEnabled) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -95,6 +95,7 @@ data class OfferMessage(
         @SerializedName("connection_id") val connectionId:              String?,
         @SerializedName("metadata")      val metadata:                  Any?,
         @SerializedName("config")        val config:                    OfferConfig? = null,
+        @SerializedName("mid")           val mid:                       Map<String, String>? = null,
         @SerializedName("encodings")     val encodings:                 List<Encoding>?,
         @SerializedName("data_channels") val dataChannels:              List<Map<String, Any>>? = null
 )


### PR DESCRIPTION
## 変更内容

- offer に mid が含まれる場合、 mid を利用して sender を設定するように修正しました
- 併せて、この PR で com.android.tools.build:gradle を 4.2.2 に更新しました

## 動作確認した内容

### mid あり

- VideoChatSample で Sora に接続して、 Sora DEMO から映像/音声を受信できる
- Logcat を `mid=` , `track=` などで検索して mid を利用するロジックが実行されていることを確認する

### mid なし

- VideoChatSample で Sora に接続して、 Sora DEMO から映像/音声を受信できる
- Logcat を `mid=` で検索して、 sora-android-sdk の mid を利用するロジックが実行されていないことを確認する
  - 設定によっては libwebrtc のログが出力されるかもしれない
  
```
# Logcat を `mid=` で検索した際にヒットするかもしれない libwebrtc のログ
2021-07-14 11:54:44.868 27448-28261/jp.shiguredo.sora.sample I/sdp_offer_answer.cc: (line 3237): Adding audio transceiver for MID=audio_FVysWJ at i=0 in response to the remote description.
2021-07-14 11:54:44.868 27448-28261/jp.shiguredo.sora.sample I/sdp_offer_answer.cc: (line 3237): Adding video transceiver for MID=video_hu1nZ8 at i=1 in response to the remote description.
2021-07-14 11:54:44.873 27448-28261/jp.shiguredo.sora.sample I/rtp_transceiver.cc: (line 273): Changing transceiver (MID=audio_FVysWJ) current direction from <not set> to kSendOnly.
2021-07-14 11:54:44.873 27448-28261/jp.shiguredo.sora.sample I/rtp_transceiver.cc: (line 273): Changing transceiver (MID=video_hu1nZ8) current direction from <not set> to kSendOnly.
```