### PR TITLE
onConnectionChange で state が failed になった場合は切断処理を実行する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@
   - @shino
 - [FIX] offer に data_channels が含まれない場合に対応する
   - @shino
-- [FIX] 切断を検知する処理を改善する
+- [FIX] 接続 / 切断を検知する処理を改善する
   - 修正前は IceConnectionState を参照していたが、 PeerConnectionState を参照するように修正する
   - SoraErrorReason の以下の値を参照するコードは修正が必要となる
     - ICE_FAILURE          => PEER_CONNECTION_FAILED

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,13 @@
   - @shino
 - [FIX] offer に data_channels が含まれない場合に対応する
   - @shino
+- [FIX] 切断を検知する処理を改善する
+  - 修正前は IceConnectionState を参照していたが、 PeerConnectionState を参照するように修正する
+  - SoraErrorReason の以下の値を参照するコードは修正が必要となる
+    - ICE_FAILURE          => PEER_CONNECTION_FAILED
+    - ICE_CLOSED_BY_SERVER => PEER_CONNECTION_CLOSED
+    - ICE_DISCONNECTED     => PEER_CONNECTION_DISCONNECTED
+  - @enm10k
 - [FIX] NotificationMessage に turnTransportType を追加する
   - @enm10k
 - [FIX] SoraSpotlightOption から simulcastRid を削除する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -219,7 +219,7 @@ class PeerChannelImpl(
                         listener?.onConnect()
                     }
                     PeerConnection.PeerConnectionState.FAILED -> {
-                        listener?.onError(SoraErrorReason.PEER_CONNECTION_FAILURE)
+                        listener?.onError(SoraErrorReason.PEER_CONNECTION_FAILED)
                         disconnect()
                     }
                     PeerConnection.PeerConnectionState.DISCONNECTED -> {
@@ -231,7 +231,7 @@ class PeerChannelImpl(
                     }
                     PeerConnection.PeerConnectionState.CLOSED -> {
                         if (!closing) {
-                            listener?.onError(SoraErrorReason.PEER_CONNECTION_CLOSED_BY_SERVER)
+                            listener?.onError(SoraErrorReason.PEER_CONNECTION_CLOSED)
                         }
                         disconnect()
                     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -194,32 +194,6 @@ class PeerChannelImpl(
 
         override fun onIceConnectionChange(state: PeerConnection.IceConnectionState?) {
             SoraLogger.d(TAG, "[rtc] @onIceConnectionChange:$state")
-            state?.let {
-               SoraLogger.d(TAG, "[rtc] @ice:${it.name}")
-               when (it) {
-                   PeerConnection.IceConnectionState.CONNECTED -> {
-                       listener?.onConnect()
-                   }
-                   PeerConnection.IceConnectionState.FAILED -> {
-                       listener?.onError(SoraErrorReason.ICE_FAILURE)
-                       disconnect()
-                   }
-                   PeerConnection.IceConnectionState.DISCONNECTED -> {
-                       if (closing) return
-
-                       // disconnected はなにもしない、ネットワークが不安定な場合は
-                       // failed に遷移して上の節で捕まえられるため、listener 通知のみ行う。
-                       listener?.onWarning(SoraErrorReason.ICE_DISCONNECTED)
-                   }
-                   PeerConnection.IceConnectionState.CLOSED -> {
-                       if (!closing) {
-                            listener?.onError(SoraErrorReason.ICE_CLOSED_BY_SERVER)
-                       }
-                       disconnect()
-                   }
-                   else -> {}
-               }
-            }
         }
 
         override fun onIceConnectionReceivingChange(received: Boolean) {
@@ -239,22 +213,25 @@ class PeerChannelImpl(
             super.onConnectionChange(newState)
             SoraLogger.d(TAG, "[rtc] @onConnectionChange:$newState")
             newState?.let {
-                SoraLogger.d(TAG, "[rtc] @ice:${it.name}")
+                SoraLogger.d(TAG, "[rtc] @pc:${it.name}")
                 when (it) {
-                    PeerConnection.PeerConnectionState.CONNECTED -> {}
+                    PeerConnection.PeerConnectionState.CONNECTED -> {
+                        listener?.onConnect()
+                    }
                     PeerConnection.PeerConnectionState.FAILED -> {
-                        listener?.onError(SoraErrorReason.PC_FAILURE)
+                        listener?.onError(SoraErrorReason.PEER_CONNECTION_FAILURE)
                         disconnect()
                     }
                     PeerConnection.PeerConnectionState.DISCONNECTED -> {
                         if (closing) return
 
-                        // onIceConnectionChange と同様に、 disconnected の場合は listener への通知に留める
-                        listener?.onWarning(SoraErrorReason.PC_DISCONNECTED)
+                        // disconnected はなにもしない、ネットワークが不安定な場合は
+                        // failed に遷移して上の節で捕まえられるため、listener 通知のみ行う。
+                        listener?.onWarning(SoraErrorReason.PEER_CONNECTION_DISCONNECTED)
                     }
                     PeerConnection.PeerConnectionState.CLOSED -> {
                         if (!closing) {
-                            listener?.onError(SoraErrorReason.PC_CLOSED_BY_SERVER)
+                            listener?.onError(SoraErrorReason.PEER_CONNECTION_CLOSED_BY_SERVER)
                         }
                         disconnect()
                     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -213,7 +213,6 @@ class PeerChannelImpl(
             super.onConnectionChange(newState)
             SoraLogger.d(TAG, "[rtc] @onConnectionChange:$newState")
             newState?.let {
-                SoraLogger.d(TAG, "[rtc] @pc:${it.name}")
                 when (it) {
                     PeerConnection.PeerConnectionState.CONNECTED -> {
                         listener?.onConnect()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
@@ -5,11 +5,15 @@ package jp.shiguredo.sora.sdk.error
  */
 enum class SoraErrorReason {
     // Sora との接続のエラー
+    // TODO: 名称を見直す
+    // - SIGNALING_FAILED
+    // - ICE_FAILED
+    // - ICE_CLOSED
     SIGNALING_FAILURE,
     ICE_FAILURE,
     ICE_CLOSED_BY_SERVER,
-    PEER_CONNECTION_FAILURE,
-    PEER_CONNECTION_CLOSED_BY_SERVER,
+    PEER_CONNECTION_FAILED,
+    PEER_CONNECTION_CLOSED,
     TIMEOUT,
 
     // Sora との接続の警告

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
@@ -8,14 +8,14 @@ enum class SoraErrorReason {
     SIGNALING_FAILURE,
     ICE_FAILURE,
     ICE_CLOSED_BY_SERVER,
-    PC_FAILURE,
-    PC_CLOSED_BY_SERVER,
+    PEER_CONNECTION_FAILURE,
+    PEER_CONNECTION_CLOSED_BY_SERVER,
 
     TIMEOUT,
 
     // Sora との接続の警告
     ICE_DISCONNECTED,
-    PC_DISCONNECTED,
+    PEER_CONNECTION_DISCONNECTED,
 
     // audio track 関連のエラー
     // cf. JavaAudioDeviceModule.AudioTrackErrorCallback

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
@@ -8,10 +8,14 @@ enum class SoraErrorReason {
     SIGNALING_FAILURE,
     ICE_FAILURE,
     ICE_CLOSED_BY_SERVER,
+    PC_FAILURE,
+    PC_CLOSED_BY_SERVER,
+
     TIMEOUT,
 
     // Sora との接続の警告
     ICE_DISCONNECTED,
+    PC_DISCONNECTED,
 
     // audio track 関連のエラー
     // cf. JavaAudioDeviceModule.AudioTrackErrorCallback

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraErrorReason.kt
@@ -10,7 +10,6 @@ enum class SoraErrorReason {
     ICE_CLOSED_BY_SERVER,
     PEER_CONNECTION_FAILURE,
     PEER_CONNECTION_CLOSED_BY_SERVER,
-
     TIMEOUT,
 
     // Sora との接続の警告


### PR DESCRIPTION
## 変更内容

- onConnectionChange で state が failed になった際に切断処理を実行するように修正しました

## 相談したい内容

- SoraErrorReason の内容
  - `ICE_` から始まるエラーをコピーして、 `PC_` から始まるエラーを追加しました