### PR TITLE
sora-android-sdk-quickstart や sora-android-sdk-samples の permissions-dispatcher を Maven Central から取得するために repositories の順番を変える

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url 'https://jitpack.io' }
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
## 変更内容

-  sora-android-sdk-quickstart や sora-android-sdk-samples を multi-module 構成でビルドする際に permissions-dispatcher を Maven Central から取得するために、 repositories の順番を修正します

## 関連する PR

- https://github.com/shiguredo/sora-android-sdk-samples/pull/36
- https://github.com/shiguredo/sora-android-sdk-quickstart/pull/9