### PR TITLE
AES-GCM を有効にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
   - @enm10k
 - [UPDATE] JCenter への参照を取り除く
   - @enm10k
+- [UPDATE] AES-GCM を有効にする
+  - @miosakuma
 - [ADD] データチャネルシグナリングに対応する
   - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
   - onDataChannel コールバックを実装する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
@@ -3,7 +3,6 @@ package jp.shiguredo.sora.sdk.channel.rtc
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
 import jp.shiguredo.sora.sdk.channel.signaling.message.OfferConfig
 import org.webrtc.CryptoOptions
-import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnection
 
 class PeerNetworkConfig(
@@ -28,7 +27,7 @@ class PeerNetworkConfig(
             .setEnableGcmCryptoSuites(true)
             .createCryptoOptions()
         conf.cryptoOptions = cryptoOptions
-        conf.enableDtlsSrtp = true;
+        conf.enableDtlsSrtp = true
         conf.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
 
         conf.tcpCandidatePolicy = mediaOption.tcpCandidatePolicy

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
@@ -2,6 +2,7 @@ package jp.shiguredo.sora.sdk.channel.rtc
 
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
 import jp.shiguredo.sora.sdk.channel.signaling.message.OfferConfig
+import org.webrtc.CryptoOptions
 import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnection
 
@@ -23,7 +24,10 @@ class PeerNetworkConfig(
         conf.rtcpMuxPolicy            = PeerConnection.RtcpMuxPolicy.REQUIRE
         conf.continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
         conf.keyType                  = PeerConnection.KeyType.ECDSA
-
+        val cryptoOptions = CryptoOptions.builder()
+            .setEnableGcmCryptoSuites(true)
+            .createCryptoOptions()
+        conf.cryptoOptions = cryptoOptions
         conf.enableDtlsSrtp = true;
         conf.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
 


### PR DESCRIPTION
以下の対応について実施しています。

- AES-GCM を有効にする
- 未使用のインポート文を削除（`org.webrtc.MediaConstraints`）
- 不要なセミコロンの削除
- 変更履歴への追加