### PR TITLE
WebRTC を M96 に更新する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@
   - SoraMediaOption.videoUpstreamContext が無く SoraMediaOption.videoDownstreamContext 
     がある場合はコーデック指定に依らず、 DefaultVideoEncoderFactory を使用する
   - @miosakuma
+- [FIX] libwebrtc の更新で発生するようになったサイマルキャストのクラッシュを修正する
+  - SimulcastVideoEncoderFactoryWrapper.kt の Fallback クラスが原因で java.lang.UnsupportedOperationException が発生していた
+  - 調査の結果、 Fallback クラスを削除できることがわかったので、その方向で修正した
+  - その過程で、 libwebrtc に適用している Android のサイマルキャスト対応のパッチを更新し、 SimulcastVideoEncoderFactory の fallback に null を指定できるようにした
+  - @enm10k
 
 ## 2021.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] libwebrtc を 96.4664.2.1 に上げる
+  - @enm10k
 - [UPDATE] 複数シグナリング URL の指定に対応する
   - @enm10k
 - [UPDATE] redirect メッセージに対応する

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.4.31'
-    ext.libwebrtc_version = '96.4664.2.0'
+    ext.libwebrtc_version = '96.4664.2.1'
 
     ext.dokka_version = '1.5.31'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.4.31'
-    ext.libwebrtc_version = '93.4577.8.2'
+    ext.libwebrtc_version = '96.4664.2.0'
 
     ext.dokka_version = '1.5.31'
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -42,7 +42,8 @@ class RTCComponentFactory(
                 SimulcastVideoEncoderFactoryWrapper(
                     mediaOption.videoUpstreamContext,
                     true,
-                    false
+                    false,
+                    mediaOption.videoCodec,
                 )
             mediaOption.videoUpstreamContext != null ->
                 DefaultVideoEncoderFactory(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -41,6 +41,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
                     SoraLogger.i(
                         TAG,
                         """initEncode() thread=${Thread.currentThread().name} [${Thread.currentThread().id}]
+                |  encoder=${encoder.implementationName}
                 |  streamSettings:
                 |    numberOfCores=${settings.numberOfCores}
                 |    width=${settings.width}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -1,5 +1,6 @@
 package jp.shiguredo.sora.sdk.codec
 
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.EglBase
 import org.webrtc.HardwareVideoEncoderFactory
@@ -17,7 +18,8 @@ import java.util.concurrent.Executors
 internal class SimulcastVideoEncoderFactoryWrapper(
     sharedContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean,
-    enableH264HighProfile: Boolean
+    enableH264HighProfile: Boolean,
+    videoCodec: SoraVideoOption.Codec
 ) : VideoEncoderFactory {
 
     // ストリーム単位のエンコーダをラップした上で以下を行うクラス。
@@ -134,7 +136,14 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             sharedContext, enableIntelVp8Encoder, enableH264HighProfile
         )
         primary = StreamEncoderWrapperFactory(hardwareVideoEncoderFactory)
-        fallback = SoftwareVideoEncoderFactory()
+
+        // H.264 のサイマルキャストを利用する場合は fallback に null を設定する
+        // Sora Android SDK では SW の H.264 を無効化しているため fallback に設定できるものがない
+        fallback = if (videoCodec != SoraVideoOption.Codec.H264) {
+            SoftwareVideoEncoderFactory()
+        } else {
+            null
+        }
         native = SimulcastVideoEncoderFactory(primary, fallback)
     }
 


### PR DESCRIPTION
## 変更内容

- WebRTC を M96 に更新しました
  - また、WebRTC の更新に伴いサイマルキャストのクラッシュが発生したので、この PR で併せて修正しています

## サイマルキャストのクラッシュの修正

WebRTC のバージョンを更新したところ、 sora-android-sdk-samples のサイマルキャストが Sora に接続した後にクラッシュするようになりました
クラッシュの原因である Fallback class を SimulcastVideoEncoderFactoryWrapper.kt から取り除く方向で修正しています

### 動作確認

sora-android-sdk-samples (Pixel 4) サイマルキャストの映像が Sora DEMO の multi_simulcast_recvonly で受信できることを確認しています

- 映像コーデック: VP8 / H.264 の両方でサイマルキャストが動作すること
- Android 端末をローテートしてもサイマルキャストが動作すること