### PR TITLE
numberOfUpstream, numberOfDownstream 関連の項目を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,15 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [CHANGE] Sora で廃止となった以下のフィールドを削除する
+  - NotificationMessage.numberOfUpstreamConnections
+  - NotificationMessage.numberOfDownstreamConnections
+  - ChannelAttendeesCount.numberOfUpstreams
+  - ChannelAttendeesCount.numberOfDownstreams
+  - @miosakuma
+
 ## 2022.1.0
 
 - [CHANGE] スポットライトレガシーを削除する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -804,9 +804,9 @@ class SoraMediaChannel @JvmOverloads constructor(
         when (notification.eventType) {
             "connection.created", "connection.destroyed" -> {
                 val attendees = ChannelAttendeesCount(
-                    numberOfSendrecvConnections = notification.numberOfSendrecvConnections!!,
-                    numberOfSendonlyConnections = notification.numberOfSendonlyConnections!!,
-                    numberOfRecvonlyConnections = notification.numberOfRecvonlyConnections!!,
+                    numberOfSendrecvConnections = notification.numberOfSendrecvConnections?: 0,
+                    numberOfSendonlyConnections = notification.numberOfSendonlyConnections?: 0,
+                    numberOfRecvonlyConnections = notification.numberOfRecvonlyConnections?: 0,
                 )
                 listener?.onAttendeesCountUpdated(this@SoraMediaChannel, attendees)
             }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -804,8 +804,6 @@ class SoraMediaChannel @JvmOverloads constructor(
         when (notification.eventType) {
             "connection.created", "connection.destroyed" -> {
                 val attendees = ChannelAttendeesCount(
-                    numberOfDownstreams = notification.numberOfDownstreamConnections ?: 0,
-                    numberOfUpstreams = notification.numberOfUpstreamConnections ?: 0,
                     numberOfSendrecvConnections = notification.numberOfSendrecvConnections!!,
                     numberOfSendonlyConnections = notification.numberOfSendonlyConnections!!,
                     numberOfRecvonlyConnections = notification.numberOfRecvonlyConnections!!,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/data/ChannelAttendeesCount.kt
@@ -5,18 +5,6 @@ package jp.shiguredo.sora.sdk.channel.data
  */
 data class ChannelAttendeesCount(
     /**
-     * 配信者数.
-     */
-    @Deprecated("numberOfUpstreams は 2021 年 6 月リリース予定の Sora にて廃止されます。")
-    val numberOfUpstreams: Int,
-
-    /**
-     * 視聴者数.
-     */
-    @Deprecated("numberOfDownstreams は 2021 年 6 月リリース予定の Sora にて廃止されます。")
-    val numberOfDownstreams: Int,
-
-    /**
      * sendrecv の接続数.
      */
     val numberOfSendrecvConnections: Int,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -162,10 +162,6 @@ data class NotificationMessage(
     @SerializedName("metadata_list") val metadataList: Any?,
     @SerializedName("minutes") val connectionTime: Long?,
     @SerializedName("channel_connections") val numberOfConnections: Int?,
-    @Deprecated("numberOfUpstreamConnections は 2021 年 6 月リリース予定の Sora にて廃止されます。")
-    @SerializedName("channel_upstream_connections") val numberOfUpstreamConnections: Int?,
-    @Deprecated("numberOfDownstreamConnections は 2021 年 6 月リリース予定の Sora にて廃止されます。")
-    @SerializedName("channel_downstream_connections") val numberOfDownstreamConnections: Int?,
     @SerializedName("channel_sendrecv_connections") val numberOfSendrecvConnections: Int?,
     @SerializedName("channel_sendonly_connections") val numberOfSendonlyConnections: Int?,
     @SerializedName("channel_recvonly_connections") val numberOfRecvonlyConnections: Int?,


### PR DESCRIPTION
### 対応内容

Sora で廃止されたフィールドについて削除を行いました。
削除したフィールドの文字列で検索して、コメント等にも存在しないことを確認済です。

### 相談したいこと
https://github.com/shiguredo/sora-android-sdk/compare/feature/delete-obsolete-field?expand=1#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R807-R809

Sora 側で項目が削除されても問題ないよう、以下のように修正した方がよいように思うのですが attendees の値が正確でなくなるくらいなら Exception で落ちた方がいいという判断なのでしょうか。
修正した方がよい場合はあわせて修正しようと思います。

`numberOfSendrecvConnections = notification.numberOfSendrecvConnections? : 0`