### PR TITLE
VideoEncoder 周りの改善

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,15 +11,16 @@
 
 ## develop
 
-- [FIX] SoraMediaOption に enableHardwareVideoEncoderResolutionAdjustment を追加する
-  - このフラグが true の場合、 HW エンコーダーに入力されるフレームの解像度が 16 の倍数になるように調整される
+- [FIX] SoraMediaOption に hardwareVideoEncoderResolutionAdjustment を追加する
+  - HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調整する
+  - デフォルトでは 16 が指定されている
   - このオプションを実装した経緯は以下の通り
-    - 解像度が 16の倍数でない場合、 HW エンコーダーの初期化がエラーになる変更が libwebrtc のメインストリームに入った
+    - 解像度が 16 の倍数でない場合、 HW エンコーダーの初期化がエラーになる変更が libwebrtc のメインストリームに入った
       - 参照: https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java;l=214-218;drc=0f50cc284949f225f663408e7d467f39d549d3dc
       - Android CTS では、 HW エンコーダー (= MediaCodec) を 16で割り切れる解像度のみでテストしており、かつ 16 で割り切れない解像度で問題が発生する端末があったことが理由で上記の変更が行われた
     - Sora Android SDK では一部の解像度が影響を受けるため、対応としてこのオプションを実装した
   - Sora Android SDK では libwebrtc にパッチを当て、上記の HW エンコーダー初期化時の解像度のチェックを無効化している
-  - そのため、このフラグを false に設定することで、従来通り、解像度を調整することなく HW エンコーダーを利用できる
+  - そのため、このフラグを SoraVideoOption.ResolutionAdjustment.NONE に設定することで、従来通り、解像度を調整することなく HW エンコーダーを利用できる
   - より詳細な情報は以下のリンクを参照
     - https://bugs.chromium.org/p/chromium/issues/detail?id=1084702
   - @enm10k

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -203,7 +203,7 @@ class SoraMediaOption {
         PeerConnection.TcpCandidatePolicy.ENABLED
 
     /**
-     * HW エンコーダー利用時の解像度を調整するフラグ.
+     * HW エンコーダー利用時の解像度を調整するパラメータ.
      * HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調節します.
      *
      * このオプションを実装した経緯は以下の通りです.

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -220,5 +220,5 @@ class SoraMediaOption {
      *
      * https://bugs.chromium.org/p/chromium/issues/detail?id=1084702
      */
-    var hardwareVideoEncoderPixelResolutionAdjustment = SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
+    var hardwareVideoEncoderResolutionAdjustment = SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -203,8 +203,8 @@ class SoraMediaOption {
         PeerConnection.TcpCandidatePolicy.ENABLED
 
     /**
-     * HW エンコーダー利用時の解像度が16の倍数になるように調整するフラグ.
-     * このフラグが true の場合、 HW エンコーダーに入力されるフレームの解像度が16の倍数になるように調節します.
+     * HW エンコーダー利用時の解像度を調整するフラグ.
+     * HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調節します.
      *
      * このオプションを実装した経緯は以下の通りです.
      * - 解像度が 16 の倍数でない場合、 HW エンコーダーの初期化がエラーになる変更が libwebrtc のメインストリームに入った
@@ -214,11 +214,11 @@ class SoraMediaOption {
      * 参照: https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java;l=214-218;drc=0f50cc284949f225f663408e7d467f39d549d3dc
      *
      * Sora Android SDK では libwebrtc にパッチを当て、上記の HW エンコーダー初期化時の解像度のチェックを無効化しています.
-     * そのため、このフラグを false に設定することで、従来通り、解像度を調整することなく HW エンコーダーを利用することも可能です.
+     * そのため、このフラグを NONE に設定することで、従来通り、解像度を調整することなく HW エンコーダーを利用することも可能です.
      *
      * より詳細な情報を確認したい場合は、以下の Chromium のイシューを参照してください.
      *
      * https://bugs.chromium.org/p/chromium/issues/detail?id=1084702
      */
-    var enableHardwareVideoEncoderResolutionAdjustment = true
+    var hardwareVideoEncoderPixelResolutionAdjustment = SoraVideoOption.PixelResolutionAdjustment.MULTIPLE_OF_16
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -220,5 +220,5 @@ class SoraMediaOption {
      *
      * https://bugs.chromium.org/p/chromium/issues/detail?id=1084702
      */
-    var hardwareVideoEncoderPixelResolutionAdjustment = SoraVideoOption.PixelResolutionAdjustment.MULTIPLE_OF_16
+    var hardwareVideoEncoderPixelResolutionAdjustment = SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -129,7 +129,7 @@ class SoraVideoOption {
     }
 
     enum class ResolutionAdjustment(val value: Int) {
-        NONE(0),
+        NONE(1),
         MULTIPLE_OF_2(2),
         MULTIPLE_OF_4(4),
         MULTIPLE_OF_8(8),

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -128,11 +128,11 @@ class SoraVideoOption {
         override fun toString(): String = value
     }
 
-    enum class ResolutionAdjustment(val value: Int) {
-        NONE(1),
-        MULTIPLE_OF_2(2),
-        MULTIPLE_OF_4(4),
-        MULTIPLE_OF_8(8),
-        MULTIPLE_OF_16(16),
+    enum class ResolutionAdjustment(val value: UInt) {
+        NONE(1u),
+        MULTIPLE_OF_2(2u),
+        MULTIPLE_OF_4(4u),
+        MULTIPLE_OF_8(8u),
+        MULTIPLE_OF_16(16u),
     }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -127,4 +127,12 @@ class SoraVideoOption {
 
         override fun toString(): String = value
     }
+
+    enum class PixelResolutionAdjustment(val value: Int) {
+        NONE(0),
+        MULTIPLE_OF_2(2),
+        MULTIPLE_OF_4(4),
+        MULTIPLE_OF_8(8),
+        MULTIPLE_OF_16(16),
+    }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -128,7 +128,7 @@ class SoraVideoOption {
         override fun toString(): String = value
     }
 
-    enum class PixelResolutionAdjustment(val value: Int) {
+    enum class ResolutionAdjustment(val value: Int) {
         NONE(0),
         MULTIPLE_OF_2(2),
         MULTIPLE_OF_4(4),

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -41,18 +41,18 @@ class RTCComponentFactory(
             mediaOption.simulcastEnabled ->
                 SimulcastVideoEncoderFactoryWrapper(
                     mediaOption.videoUpstreamContext,
-                    enableResolutionAdjustment = mediaOption.enableHardwareVideoEncoderResolutionAdjustment,
+                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
                 )
             mediaOption.videoUpstreamContext != null ->
                 SoraDefaultVideoEncoderFactory(
                     mediaOption.videoUpstreamContext,
-                    enableResolutionAdjustment = mediaOption.enableHardwareVideoEncoderResolutionAdjustment,
+                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
                 )
 
             mediaOption.videoDownstreamContext != null ->
                 SoraDefaultVideoEncoderFactory(
                     mediaOption.videoDownstreamContext,
-                    enableResolutionAdjustment = mediaOption.enableHardwareVideoEncoderResolutionAdjustment,
+                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
                 )
             else ->
                 // context が指定されていなければソフトウェアエンコーダーを使用する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -41,7 +41,6 @@ class RTCComponentFactory(
             mediaOption.simulcastEnabled ->
                 SimulcastVideoEncoderFactoryWrapper(
                     mediaOption.videoUpstreamContext,
-                    videoCodec = mediaOption.videoCodec,
                     enableResolutionAdjustment = mediaOption.enableHardwareVideoEncoderResolutionAdjustment,
                 )
             mediaOption.videoUpstreamContext != null ->

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -41,18 +41,18 @@ class RTCComponentFactory(
             mediaOption.simulcastEnabled ->
                 SimulcastVideoEncoderFactoryWrapper(
                     mediaOption.videoUpstreamContext,
-                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
+                    resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,
                 )
             mediaOption.videoUpstreamContext != null ->
                 SoraDefaultVideoEncoderFactory(
                     mediaOption.videoUpstreamContext,
-                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
+                    resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,
                 )
 
             mediaOption.videoDownstreamContext != null ->
                 SoraDefaultVideoEncoderFactory(
                     mediaOption.videoDownstreamContext,
-                    resolutionPixelAlignment = mediaOption.hardwareVideoEncoderPixelResolutionAdjustment.value,
+                    resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,
                 )
             else ->
                 // context が指定されていなければソフトウェアエンコーダーを使用する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -10,7 +10,7 @@ import org.webrtc.VideoFrame
 
 internal class HardwareVideoEncoderWrapper(
     private val encoder: VideoEncoder,
-    private val pixelAlignment: Int,
+    private val resolutionPixelAlignment: Int = 0,
 ) : VideoEncoder {
     class CropSizeCalculator(private val originalSettings: VideoEncoder.Settings, private val resolutionPixelAlignment: Int) {
 
@@ -108,7 +108,7 @@ internal class HardwareVideoEncoderWrapper(
 
     override fun initEncode(settings: VideoEncoder.Settings, callback: VideoEncoder.Callback?): VideoCodecStatus {
         return try {
-            calculator = CropSizeCalculator(settings, pixelAlignment)
+            calculator = CropSizeCalculator(settings, resolutionPixelAlignment)
             encoder.initEncode(calculator!!.settings, callback)
         } catch (e: Exception) {
             SoraLogger.e(TAG, "initEncode failed", e)
@@ -165,7 +165,7 @@ internal class HardwareVideoEncoderWrapper(
 
 internal class HardwareVideoEncoderWrapperFactory(
     private val factory: HardwareVideoEncoderFactory,
-    private val resolutionPixelAlignment: Int,
+    private val resolutionPixelAlignment: Int = 0
 ) : VideoEncoderFactory {
     companion object {
         val TAG = HardwareVideoEncoderWrapperFactory::class.simpleName

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -141,7 +141,7 @@ internal class HardwareVideoEncoderWrapper(
                     result
                 }
             } ?: run {
-                // helper は null にならない想定だが force unwrap を防ぐためにこのように記述する
+                // null にならない想定だが force unwrap を防ぐためにこのように記述する
                 VideoCodecStatus.ERROR
             }
         } catch (e: Exception) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -156,12 +156,19 @@ internal class HardwareVideoEncoderWrapper(
 internal class HardwareVideoEncoderWrapperFactory(
     private val factory: HardwareVideoEncoderFactory,
 ) : VideoEncoderFactory {
+    private val TAG = HardwareVideoEncoderWrapperFactory::class.simpleName
+
     override fun createEncoder(videoCodecInfo: VideoCodecInfo?): VideoEncoder? {
-        val encoder = factory.createEncoder(videoCodecInfo)
-        if (encoder == null) {
+        try {
+            val encoder = factory.createEncoder(videoCodecInfo)
+            if (encoder == null) {
+                return null
+            }
+            return HardwareVideoEncoderWrapper(encoder)
+        } catch (e: Exception) {
+            SoraLogger.e(TAG, "createEncoder failed", e)
             return null
         }
-        return HardwareVideoEncoderWrapper(encoder)
     }
 
     override fun getSupportedCodecs(): Array<VideoCodecInfo> {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -144,6 +144,7 @@ internal class HardwareVideoEncoderWrapper(
                 }
             } ?: run {
                 // null にならない想定だが force unwrap を防ぐためにこのように記述する
+                SoraLogger.e(TAG, "calculator is null")
                 VideoCodecStatus.ERROR
             }
         } catch (e: Exception) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -10,7 +10,7 @@ import org.webrtc.VideoFrame
 
 internal class HardwareVideoEncoderWrapper(
     private val encoder: VideoEncoder,
-    private val resolutionPixelAlignment: Int = 0,
+    private val resolutionPixelAlignment: Int,
 ) : VideoEncoder {
     class CropSizeCalculator(private val originalSettings: VideoEncoder.Settings, private val resolutionPixelAlignment: Int) {
 
@@ -48,7 +48,7 @@ internal class HardwareVideoEncoderWrapper(
         private var lastFrameHeight: Int = 0
 
         init {
-            SoraLogger.i(TAG, "$this init")
+            SoraLogger.i(TAG, "$this init: resolutionPixelAlignment=$resolutionPixelAlignment")
 
             lastFrameWidth = originalSettings.width
             lastFrameHeight = originalSettings.height

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -10,9 +10,9 @@ import org.webrtc.VideoFrame
 
 internal class HardwareVideoEncoderWrapper(
     private val encoder: VideoEncoder,
-    private val resolutionPixelAlignment: Int,
+    private val resolutionPixelAlignment: UInt,
 ) : VideoEncoder {
-    class CropSizeCalculator(private val originalSettings: VideoEncoder.Settings, private val resolutionPixelAlignment: Int) {
+    class CropSizeCalculator(private val originalSettings: VideoEncoder.Settings, private val resolutionPixelAlignment: UInt) {
 
         companion object {
             val TAG = CropSizeCalculator::class.simpleName
@@ -57,8 +57,8 @@ internal class HardwareVideoEncoderWrapper(
         }
 
         private fun calculate(width: Int, height: Int) {
-            cropX = width % resolutionPixelAlignment
-            cropY = height % resolutionPixelAlignment
+            cropX = width % resolutionPixelAlignment.toInt()
+            cropY = height % resolutionPixelAlignment.toInt()
 
             if (cropX != 0 || cropY != 0) {
                 SoraLogger.i(
@@ -167,10 +167,16 @@ internal class HardwareVideoEncoderWrapper(
 
 internal class HardwareVideoEncoderWrapperFactory(
     private val factory: HardwareVideoEncoderFactory,
-    private val resolutionPixelAlignment: Int,
+    private val resolutionPixelAlignment: UInt,
 ) : VideoEncoderFactory {
     companion object {
         val TAG = HardwareVideoEncoderWrapperFactory::class.simpleName
+    }
+
+    init {
+        if (resolutionPixelAlignment == 0u) {
+            throw java.lang.Exception("resolutionPixelAlignment should not be 0")
+        }
     }
 
     override fun createEncoder(videoCodecInfo: VideoCodecInfo?): VideoEncoder? {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -107,6 +107,7 @@ internal class HardwareVideoEncoderWrapper(
     private var calculator: CropSizeCalculator? = null
 
     override fun initEncode(settings: VideoEncoder.Settings, callback: VideoEncoder.Callback?): VideoCodecStatus {
+        // エンコーダーが利用している MediaCodec で例外が発生した際、 try, catch がないとフォールバックが動作しなかった
         return try {
             calculator = CropSizeCalculator(settings, resolutionPixelAlignment)
             encoder.initEncode(calculator!!.settings, callback)
@@ -121,6 +122,7 @@ internal class HardwareVideoEncoderWrapper(
     }
 
     override fun encode(frame: VideoFrame, encodeInfo: VideoEncoder.EncodeInfo?): VideoCodecStatus {
+        // エンコーダーが利用している MediaCodec で例外が発生した際、 try, catch がないとフォールバックが動作しなかった
         try {
             return calculator?.let {
                 it.recalculateIfNeeded(frame)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/HardwareVideoEncoderWrapperFactory.kt
@@ -165,7 +165,7 @@ internal class HardwareVideoEncoderWrapper(
 
 internal class HardwareVideoEncoderWrapperFactory(
     private val factory: HardwareVideoEncoderFactory,
-    private val resolutionPixelAlignment: Int = 0
+    private val resolutionPixelAlignment: Int,
 ) : VideoEncoderFactory {
     companion object {
         val TAG = HardwareVideoEncoderWrapperFactory::class.simpleName

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -1,6 +1,5 @@
 package jp.shiguredo.sora.sdk.codec
 
-import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.EglBase
 import org.webrtc.HardwareVideoEncoderFactory
@@ -19,7 +18,6 @@ internal class SimulcastVideoEncoderFactoryWrapper(
     sharedContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean = true,
     enableH264HighProfile: Boolean = false,
-    videoCodec: SoraVideoOption.Codec,
     enableResolutionAdjustment: Boolean = true
 ) : VideoEncoderFactory {
 
@@ -156,13 +154,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             )
         )
 
-        // Sora Android SDK では H.264 の SW エンコーダーを無効化しているため、 fallback に設定できない
-        // 代わりに、解像度調整が自動で行われない HardwareVideoEncoderFactory を fallback として設定する
-        fallback = if (videoCodec != SoraVideoOption.Codec.H264) {
-            SoftwareVideoEncoderFactory()
-        } else {
-            hardwareVideoEncoderFactory
-        }
+        fallback = SoftwareVideoEncoderFactory()
         native = SimulcastVideoEncoderFactory(primary, fallback)
     }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -156,12 +156,12 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             )
         )
 
-        // H.264 のサイマルキャストを利用する場合は fallback に null を設定する
-        // Sora Android SDK では SW の H.264 を無効化しているため fallback に設定できるものがない
+        // Sora Android SDK では H.264 の SW エンコーダーを無効化しているため、 fallback に設定できない
+        // 代わりに、解像度調整が自動で行われない HardwareVideoEncoderFactory を fallback として設定する
         fallback = if (videoCodec != SoraVideoOption.Codec.H264) {
             SoftwareVideoEncoderFactory()
         } else {
-            null
+            hardwareVideoEncoderFactory
         }
         native = SimulcastVideoEncoderFactory(primary, fallback)
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -1,5 +1,6 @@
 package jp.shiguredo.sora.sdk.codec
 
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.EglBase
 import org.webrtc.HardwareVideoEncoderFactory
@@ -18,7 +19,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
     sharedContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean = true,
     enableH264HighProfile: Boolean = false,
-    resolutionPixelAlignment: Int,
+    resolutionAdjustment: SoraVideoOption.ResolutionAdjustment,
 ) : VideoEncoderFactory {
 
     // ストリーム単位のエンコーダをラップした上で以下を行うクラス。
@@ -145,17 +146,15 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             sharedContext, enableIntelVp8Encoder, enableH264HighProfile
         )
 
-        val encoder = if (resolutionPixelAlignment == 0) {
+        val encoderFactory = if (resolutionAdjustment == SoraVideoOption.ResolutionAdjustment.NONE) {
             hardwareVideoEncoderFactory
         } else {
-            StreamEncoderWrapperFactory(
-                HardwareVideoEncoderWrapperFactory(
-                    hardwareVideoEncoderFactory, resolutionPixelAlignment
-                )
+            HardwareVideoEncoderWrapperFactory(
+                hardwareVideoEncoderFactory, resolutionAdjustment.value
             )
         }
 
-        primary = encoder
+        primary = StreamEncoderWrapperFactory(encoderFactory)
         fallback = SoftwareVideoEncoderFactory()
         native = SimulcastVideoEncoderFactory(primary, fallback)
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -18,7 +18,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
     sharedContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean = true,
     enableH264HighProfile: Boolean = false,
-    enableResolutionAdjustment: Boolean = true
+    resolutionPixelAlignment: Int,
 ) : VideoEncoderFactory {
 
     // ストリーム単位のエンコーダをラップした上で以下を行うクラス。
@@ -145,15 +145,17 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             sharedContext, enableIntelVp8Encoder, enableH264HighProfile
         )
 
-        // 解像度が奇数の場合、偶数になるように調整する
-        val resolutionPixelAlignment = if (enableResolutionAdjustment) { 16 } else { 2 }
-
-        primary = StreamEncoderWrapperFactory(
-            HardwareVideoEncoderWrapperFactory(
-                hardwareVideoEncoderFactory, resolutionPixelAlignment
+        val encoder = if (resolutionPixelAlignment == 0) {
+            hardwareVideoEncoderFactory
+        } else {
+            StreamEncoderWrapperFactory(
+                HardwareVideoEncoderWrapperFactory(
+                    hardwareVideoEncoderFactory, resolutionPixelAlignment
+                )
             )
-        )
+        }
 
+        primary = encoder
         fallback = SoftwareVideoEncoderFactory()
         native = SimulcastVideoEncoderFactory(primary, fallback)
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -147,13 +147,14 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             sharedContext, enableIntelVp8Encoder, enableH264HighProfile
         )
 
-        primary = if (enableResolutionAdjustment) {
-            StreamEncoderWrapperFactory(
-                HardwareVideoEncoderWrapperFactory(hardwareVideoEncoderFactory)
+        // 解像度が奇数の場合、偶数になるように調整する
+        val resolutionPixelAlignment = if (enableResolutionAdjustment) { 16 } else { 2 }
+
+        primary = StreamEncoderWrapperFactory(
+            HardwareVideoEncoderWrapperFactory(
+                hardwareVideoEncoderFactory, resolutionPixelAlignment
             )
-        } else {
-            StreamEncoderWrapperFactory(hardwareVideoEncoderFactory)
-        }
+        )
 
         // H.264 のサイマルキャストを利用する場合は fallback に null を設定する
         // Sora Android SDK では SW の H.264 を無効化しているため fallback に設定できるものがない

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
@@ -19,11 +19,10 @@ internal class SoraDefaultVideoEncoderFactory(
 
     init {
         val defaultFactory = HardwareVideoEncoderFactory(eglContext, enableIntelVp8Encoder, enableH264HighProfile)
-        hardwareVideoEncoderFactory = if (enableResolutionAdjustment) {
-            HardwareVideoEncoderWrapperFactory(defaultFactory)
-        } else {
-            defaultFactory
-        }
+
+        // 解像度が奇数の場合、偶数になるように調整する
+        val resolutionPixelAlignment = if (enableResolutionAdjustment) { 16 } else { 2 }
+        hardwareVideoEncoderFactory = HardwareVideoEncoderWrapperFactory(defaultFactory, resolutionPixelAlignment)
     }
 
     override fun createEncoder(info: VideoCodecInfo): VideoEncoder? {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
@@ -21,7 +21,7 @@ internal class SoraDefaultVideoEncoderFactory(
     init {
         val defaultFactory = HardwareVideoEncoderFactory(eglContext, enableIntelVp8Encoder, enableH264HighProfile)
 
-        // 解像度が奇数の場合、偶数になるように調整する
+        // 解像度の調整が必要な場合、改造した VideoEncoderFactory を利用する
         hardwareVideoEncoderFactory = if (resolutionAdjustment == SoraVideoOption.ResolutionAdjustment.NONE) {
             defaultFactory
         } else {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
@@ -12,7 +12,7 @@ internal class SoraDefaultVideoEncoderFactory(
     eglContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean = true,
     enableH264HighProfile: Boolean = false,
-    enableResolutionAdjustment: Boolean,
+    resolutionPixelAlignment: Int
 ) : VideoEncoderFactory {
     private val hardwareVideoEncoderFactory: VideoEncoderFactory
     private val softwareVideoEncoderFactory: VideoEncoderFactory = SoftwareVideoEncoderFactory()
@@ -21,8 +21,12 @@ internal class SoraDefaultVideoEncoderFactory(
         val defaultFactory = HardwareVideoEncoderFactory(eglContext, enableIntelVp8Encoder, enableH264HighProfile)
 
         // 解像度が奇数の場合、偶数になるように調整する
-        val resolutionPixelAlignment = if (enableResolutionAdjustment) { 16 } else { 2 }
-        hardwareVideoEncoderFactory = HardwareVideoEncoderWrapperFactory(defaultFactory, resolutionPixelAlignment)
+        val encoderFactory = if (resolutionPixelAlignment == 0) {
+            defaultFactory
+        } else {
+            HardwareVideoEncoderWrapperFactory(defaultFactory, resolutionPixelAlignment)
+        }
+        hardwareVideoEncoderFactory = encoderFactory
     }
 
     override fun createEncoder(info: VideoCodecInfo): VideoEncoder? {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SoraDefaultVideoEncoderFactory.kt
@@ -1,5 +1,6 @@
 package jp.shiguredo.sora.sdk.codec
 
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import org.webrtc.EglBase
 import org.webrtc.HardwareVideoEncoderFactory
 import org.webrtc.SoftwareVideoEncoderFactory
@@ -12,7 +13,7 @@ internal class SoraDefaultVideoEncoderFactory(
     eglContext: EglBase.Context?,
     enableIntelVp8Encoder: Boolean = true,
     enableH264HighProfile: Boolean = false,
-    resolutionPixelAlignment: Int
+    resolutionAdjustment: SoraVideoOption.ResolutionAdjustment
 ) : VideoEncoderFactory {
     private val hardwareVideoEncoderFactory: VideoEncoderFactory
     private val softwareVideoEncoderFactory: VideoEncoderFactory = SoftwareVideoEncoderFactory()
@@ -21,12 +22,11 @@ internal class SoraDefaultVideoEncoderFactory(
         val defaultFactory = HardwareVideoEncoderFactory(eglContext, enableIntelVp8Encoder, enableH264HighProfile)
 
         // 解像度が奇数の場合、偶数になるように調整する
-        val encoderFactory = if (resolutionPixelAlignment == 0) {
+        hardwareVideoEncoderFactory = if (resolutionAdjustment == SoraVideoOption.ResolutionAdjustment.NONE) {
             defaultFactory
         } else {
-            HardwareVideoEncoderWrapperFactory(defaultFactory, resolutionPixelAlignment)
+            HardwareVideoEncoderWrapperFactory(defaultFactory, resolutionAdjustment.value)
         }
-        hardwareVideoEncoderFactory = encoderFactory
     }
 
     override fun createEncoder(info: VideoCodecInfo): VideoEncoder? {


### PR DESCRIPTION
### 変更内容

- HW エンコーダーの初期化が失敗した場合、 SW エンコーダーにフォールバックできるように try, catch を利用する
- 解像度が奇数の場合、偶数にする
- ~H.264 のサイマルキャストで (解像度の調整を行わない) HardwareVideoEncoderFactory を fallback に設定する~
  - ~非サイマルキャストの SoraDefaultVideoEncoderFactory でも対応するべきかは悩んでいます~
  - ~そもそも、 SimulcastVideoEncoderFactoryWrapper がクライアントから設定された videCodec に基づいて動く設計になっている点に問題が無いか確認したいです~
  ~(本当は SDP を見るべき?)~
  - [df58362](https://github.com/shiguredo/sora-android-sdk/pull/75/commits/df5836279669fcdc469f4c4c527ba92f62030f16) で対応済み