### PR TITLE
プロキシー対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [UPDATE] libwebrtc を 102.5005.7.1 に上げる
   - @miosakuma
-- [ADD] HTTP プロキシに対応する
+- [ADD] HTTP プロキシーに対応する
   - @enm10k
 - [FIX] SoraMediaOption に hardwareVideoEncoderResolutionAdjustment を追加する
   - HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調整する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] libwebrtc を 102.5005.7.1 に上げる
   - @miosakuma
+- [ADD] HTTP プロキシに対応する
+  - @enm10k
 - [FIX] SoraMediaOption に hardwareVideoEncoderResolutionAdjustment を追加する
   - HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調整する
   - デフォルトでは 16 が指定されている

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [UPDATE] libwebrtc を 102.5005.7.1 に上げる
   - @miosakuma
-- [ADD] HTTP プロキシーに対応する
+- [ADD] HTTP プロキシに対応する
   - @enm10k
 - [FIX] SoraMediaOption に hardwareVideoEncoderResolutionAdjustment を追加する
   - HW エンコーダーに入力されるフレームの解像度が指定された数の倍数になるように調整する

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     // required by "signaling" part
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
     // required by "rtc" part
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -465,7 +465,6 @@ class SoraMediaChannel @JvmOverloads constructor(
             signaling?.disconnect(null)
 
             SoraLogger.i(TAG, "[channel:$role] opening new SignalingChannel")
-
             val handler = Handler(Looper.getMainLooper())
             handler.post() {
                 connectSignalingChannel(clientOffer, location)
@@ -729,7 +728,6 @@ class SoraMediaChannel @JvmOverloads constructor(
                         if (it.isFailure) {
                             SoraLogger.d(TAG, "[channel:$role] failed to create client offer SDP: ${it.exceptionOrNull()?.message}")
                         }
-
                         val handler = Handler(Looper.getMainLooper())
                         clientOffer = it.getOrNull()
                         handler.post() {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -486,7 +486,7 @@ class SoraMediaChannel @JvmOverloads constructor(
         var builder = OkHttpClient.Builder().readTimeout(0, TimeUnit.MILLISECONDS)
 
         if (mediaOption.proxy.type != ProxyType.NONE) {
-            // org.webrtc.ProxyType を Proxy.Type に変換する
+            // org.webrtc.ProxyType を java.net.Proxy.Type に変換する
             val proxyType = when (mediaOption.proxy.type) {
                 ProxyType.HTTPS -> Proxy.Type.HTTP
                 ProxyType.SOCKS5 -> Proxy.Type.SOCKS

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -494,6 +494,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             }
 
             builder = builder.proxy(Proxy(proxyType, InetSocketAddress(mediaOption.proxy.hostname, mediaOption.proxy.port)))
+            SoraLogger.i(TAG, "proxy: ${mediaOption.proxy}")
 
             if (mediaOption.proxy.username.isNotBlank()) {
                 builder = builder.proxyAuthenticator { _, response ->

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -498,6 +498,13 @@ class SoraMediaChannel @JvmOverloads constructor(
 
             if (mediaOption.proxy.username.isNotBlank()) {
                 builder = builder.proxyAuthenticator { _, response ->
+                    // プロキシーの認証情報が誤っていた場合リトライしない
+                    // https://square.github.io/okhttp/recipes/#handling-authentication-kt-java
+                    if (response.request.header("Proxy-Authorization") != null) {
+                        SoraLogger.i(TAG, "proxy authorization failed")
+                        return@proxyAuthenticator null
+                    }
+
                     val credential = Credentials.basic(mediaOption.proxy.username, mediaOption.proxy.password)
                     response.request.newBuilder()
                         .header("Proxy-Authorization", credential)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -223,7 +223,7 @@ class SoraMediaOption {
     var hardwareVideoEncoderResolutionAdjustment = SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
 
     /**
-     * プロキシー
+     * プロキシ
      */
     var proxy: SoraProxyOption = SoraProxyOption()
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -221,4 +221,9 @@ class SoraMediaOption {
      * https://bugs.chromium.org/p/chromium/issues/detail?id=1084702
      */
     var hardwareVideoEncoderResolutionAdjustment = SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
+
+    /**
+     * プロキシー
+     */
+    var proxy: SoraProxyOption = SoraProxyOption()
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
@@ -1,0 +1,27 @@
+package jp.shiguredo.sora.sdk.channel.option
+
+import org.webrtc.ProxyType
+
+/**
+ * プロキシーに関するオプションをまとめるクラスです.
+ */
+class SoraProxyOption {
+
+    /** 種類 */
+    var type = ProxyType.NONE
+
+    /** エージェント */
+    var agent: String = "Sora Android SDK"
+
+    /** ホスト名 */
+    var hostname: String = ""
+
+    /** ポート */
+    var port: Int = 0
+
+    /** ユーザー名 */
+    var username: String = ""
+
+    /** パスワード */
+    var password: String = ""
+}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
@@ -4,7 +4,7 @@ import jp.shiguredo.sora.sdk.util.SDKInfo
 import org.webrtc.ProxyType
 
 /**
- * プロキシーに関するオプションをまとめるクラスです.
+ * プロキシに関するオプションをまとめるクラスです.
  */
 class SoraProxyOption {
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
@@ -1,5 +1,6 @@
 package jp.shiguredo.sora.sdk.channel.option
 
+import jp.shiguredo.sora.sdk.util.SDKInfo
 import org.webrtc.ProxyType
 
 /**
@@ -11,7 +12,7 @@ class SoraProxyOption {
     var type = ProxyType.NONE
 
     /** エージェント */
-    var agent: String = "Sora Android SDK"
+    var agent: String = SDKInfo.sdkInfo()
 
     /** ホスト名 */
     var hostname: String = ""

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
@@ -24,4 +24,8 @@ class SoraProxyOption {
 
     /** パスワード */
     var password: String = ""
+
+    override fun toString(): String {
+        return "type=$type, agent=$agent, hostname=$hostname, port=$port, username=$username, password=${"*".repeat(password.length)}"
+    }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraProxyOption.kt
@@ -27,6 +27,6 @@ class SoraProxyOption {
     var password: String = ""
 
     override fun toString(): String {
-        return "type=$type, agent=$agent, hostname=$hostname, port=$port, username=$username, password=${"*".repeat(password.length)}"
+        return "type=$type, hostname=$hostname, port=$port, username=$username, password=${"*".repeat(password.length)}, agent=$agent"
     }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -17,7 +17,9 @@ import org.webrtc.Logging
 import org.webrtc.MediaStream
 import org.webrtc.MediaStreamTrack
 import org.webrtc.PeerConnection
+import org.webrtc.PeerConnectionDependencies
 import org.webrtc.PeerConnectionFactory
+import org.webrtc.ProxyType
 import org.webrtc.RTCStatsCollectorCallback
 import org.webrtc.RTCStatsReport
 import org.webrtc.RtpParameters
@@ -470,9 +472,21 @@ class PeerChannelImpl(
         factory = componentFactory.createPeerConnectionFactory(appContext)
 
         SoraLogger.d(TAG, "createPeerConnection")
+        val dependenciesBuilder = PeerConnectionDependencies.builder(connectionObserver)
+        if (mediaOption.proxy.type != ProxyType.NONE) {
+            dependenciesBuilder.setProxy(
+                mediaOption.proxy.type,
+                mediaOption.proxy.agent,
+                mediaOption.proxy.hostname,
+                mediaOption.proxy.port,
+                mediaOption.proxy.username,
+                mediaOption.proxy.password,
+            )
+        }
+        val dependencies = dependenciesBuilder.createPeerConnectionDependencies()
         conn = factory!!.createPeerConnection(
             networkConfig.createConfiguration(),
-            connectionObserver
+            dependencies
         )
 
         SoraLogger.d(TAG, "local managers' initTrack: audio")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -83,6 +83,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
             var builder = OkHttpClient.Builder().readTimeout(0, TimeUnit.MILLISECONDS)
 
             if (mediaOption.proxy.type != ProxyType.NONE) {
+                SoraLogger.i(TAG, "proxy: ${mediaOption.proxy}")
                 // org.webrtc.ProxyType を Proxy.Type に変換する
                 val proxyType = when (mediaOption.proxy.type) {
                     ProxyType.HTTPS -> Proxy.Type.HTTP
@@ -91,14 +92,14 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 }
 
                 builder = builder.proxy(Proxy(proxyType, InetSocketAddress(mediaOption.proxy.hostname, mediaOption.proxy.port)))
-                SoraLogger.i(TAG, "proxy: ${mediaOption.proxy}")
 
                 if (mediaOption.proxy.username.isNotBlank()) {
                     builder = builder.proxyAuthenticator { _, response ->
                         // プロキシーの認証情報が誤っていた場合リトライしない
                         // https://square.github.io/okhttp/recipes/#handling-authentication-kt-java
                         if (response.request.header("Proxy-Authorization") != null) {
-                            SoraLogger.e(TAG, "proxy authorization failed: ${mediaOption.proxy}")
+                            SoraLogger.e(TAG, "proxy authorization failed. proxy: ${mediaOption.proxy}")
+                            SoraLogger.e(TAG, "response from proxy: code=${response.code}, headers=${response.headers}, body=${response.message}")
                             return@proxyAuthenticator null
                         }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -18,7 +18,6 @@ import okhttp3.WebSocketListener
 import okio.ByteString
 import org.webrtc.RTCStatsReport
 import org.webrtc.SessionDescription
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface SignalingChannel {
@@ -47,6 +46,7 @@ interface SignalingChannel {
 }
 
 class SignalingChannelImpl @JvmOverloads constructor(
+    private val client: OkHttpClient,
     private val endpoints: List<String>,
     private val role: SoraChannelRole,
     private val channelId: String,
@@ -59,15 +59,12 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val clientId: String? = null,
     private val signalingNotifyMetadata: Any? = null,
     private val connectDataChannels: List<Map<String, Any>>? = null,
-    private val redirect: Boolean = false
+    private val redirect: Boolean = false,
 ) : SignalingChannel {
 
     companion object {
         private val TAG = SignalingChannelImpl::class.simpleName
     }
-
-    private val client =
-        OkHttpClient.Builder().readTimeout(0, TimeUnit.MILLISECONDS).build()
 
     /*
       接続中 (= type: connect を送信する前) は複数の WebSocket が存在する可能性がある

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -76,7 +76,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
     init {
         // OkHttpClient は main スレッドで初期化しない
-        // プロキシーとしてホスト名が指定された場合に名前解決のためのネットワーク通信が発生し、
+        // プロキシの設定としてホスト名が指定された場合、名前解決のネットワーク通信が発生し、
         // android.os.NetworkOnMainThreadException が起きてしまう
         // それを防ぐためにコルーチンを利用して別スレッドで初期化する
         client = runBlocking(Dispatchers.IO) {
@@ -95,7 +95,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
                 if (mediaOption.proxy.username.isNotBlank()) {
                     builder = builder.proxyAuthenticator { _, response ->
-                        // プロキシーの認証情報が誤っていた場合リトライしない
+                        // プロキシの認証情報が誤っていた場合リトライしない
                         // https://square.github.io/okhttp/recipes/#handling-authentication-kt-java
                         if (response.request.header("Proxy-Authorization") != null) {
                             SoraLogger.e(TAG, "proxy authorization failed. proxy: ${mediaOption.proxy}")


### PR DESCRIPTION
## 変更内容

- プロキシーに対応しました

## OS の Wi-Fi に設定されたプロキシーの情報を参照すべきか否か?

Android では OS の Wi-Fi に設定したプロキシーの情報をシステム・プロパティーから参照できますが、この PR では対応していません。

参照: https://docs.oracle.com/javase/jp/6/technotes/guides/net/proxies.html
> - http.proxyHost: プロキシサーバーのホスト名
> - http.proxyPort: ポート番号 (デフォルト値は 80)
> - http.nonProxyHosts: プロキシを省略して、直接到達するホストのリスト。これは、「|」で区切られた正規表現のリストです。これらの正規表現に一致するすべてのホストに対して、プロキシを経由せずに接続が直接実行されます

以下の点を考慮し対応不要と判断していますが、議論の余地はあると思います。

- Android の Wi-Fi 設定には、プロキシーの認証情報 (ユーザー名、パスワード) を指定する項目がない