### PR TITLE
recvonly で送信した時に シグナリングでエラーになる不具合の対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,13 +9,11 @@
 - FIX
     - バグ修正
 
-## feature/make-mid-required
+## develop
 
 - [CHANGE] type: offer の mid を必須にする
   - この修正の結果、 type: offer に mid が含まれない場合は、エラーになります
   - @enm10k
-
-## develop
 
 ## 2022.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - [CHANGE] type: offer の mid を必須にする
   - この修正の結果、 type: offer に mid が含まれない場合は、エラーになります
   - @enm10k
+- [FIX] mid を nullable に変更する
+  - 「type: offer の mid を必須にする」の対応で role が recvonly の時にエラーとなる不具合の修正
+  - @miosakuma
 
 ## 2022.3.0
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -37,7 +37,7 @@ import java.util.zip.DeflaterInputStream
 interface PeerChannel {
     fun handleInitialRemoteOffer(
         offer: String,
-        mid: Map<String, String>,
+        mid: Map<String, String>?,
         encodings: List<Encoding>?
     ): Single<SessionDescription>
     fun handleUpdatedRemoteOffer(offer: String): Single<SessionDescription>
@@ -330,7 +330,7 @@ class PeerChannelImpl(
 
     override fun handleInitialRemoteOffer(
         offer: String,
-        mid: Map<String, String>,
+        mid: Map<String, String>?,
         encodings: List<Encoding>?
     ): Single<SessionDescription> {
         val offerSDP = SessionDescription(SessionDescription.Type.OFFER, offer)
@@ -346,13 +346,13 @@ class PeerChannelImpl(
 
             // 問題が発生したら reactivex の onError で捕まえられるので、 force unwrap している
             // setTrack 内も同様
-            mid.get("audio")?.let { mid ->
+            mid?.get("audio")?.let { mid ->
                 localAudioManager.track?.let { track ->
                     setTrack(mid, track)
                 }
-            } ?: SoraLogger.d(TAG, "mid for aduio not found")
+            } ?: SoraLogger.d(TAG, "mid for audio not found")
 
-            mid.get("video")?.let { mid ->
+            mid?.get("video")?.let { mid ->
                 localVideoManager?.track?.let { track ->
                     setTrack(mid, track)
                 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -103,7 +103,7 @@ data class OfferMessage(
     @SerializedName("connection_id") val connectionId: String,
     @SerializedName("metadata") val metadata: Any?,
     @SerializedName("config") val config: OfferConfig? = null,
-    @SerializedName("mid") val mid: Map<String, String>,
+    @SerializedName("mid") val mid: Map<String, String>? = null,
     @SerializedName("encodings") val encodings: List<Encoding>?,
     @SerializedName("data_channels") val dataChannels: List<Map<String, Any>>? = null
 )


### PR DESCRIPTION
Catalog.kt を nullable にするところを起点に、コンパイルエラーを修正していく形で修正しています。

結果、recvonly でもエラーとならないこと、sendrecv, sendonly でも正常に動作することを確認しています。
修正内容が正しいかを確認いただけますか。