### PR TITLE
Encoder, Decoder の fallback を DefaultVideo(Encoder|Decoder)Factory に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,7 @@
 - [FIX] EGLContext が取れなかった場合、DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
     - EGLContext が取れなかった場合の Decoder を SoftwareVideoDecoderFactory から DefaultVideoDecoderFactory に変更する
     - EGLContext が取れなかった場合の Encoder を SoftwareVideoEncoderFactory から SoraDefaultVideoEncoderFactory に変更する
-    - EGLContext は null でも Hardware を使用する MediaCodec は動作するため HW も動作可能な が取れなかった場合、DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
+    - EGLContext は null でも Hardware を使用する MediaCodec は動作するため HW も動作可能な DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
     - @miosakuma
 
 ## 2022.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,11 @@
 - [FIX] mid を nullable に変更する
     - 「type: offer の mid を必須にする」の対応で role が recvonly の時にエラーとなる不具合の修正
     - @miosakuma
+- [FIX] EGLContext が取れなかった場合、DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
+    - EGLContext が取れなかった場合の Decoder を SoftwareVideoDecoderFactory から DefaultVideoDecoderFactory に変更する
+    - EGLContext が取れなかった場合の Encoder を SoftwareVideoEncoderFactory から SoraDefaultVideoEncoderFactory に変更する
+    - EGLContext は null でも Hardware を使用する MediaCodec は動作するため HW も動作可能な が取れなかった場合、DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
+    - @miosakuma
 
 ## 2022.3.0
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -9,8 +9,6 @@ import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.DefaultVideoDecoderFactory
 import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnectionFactory
-import org.webrtc.SoftwareVideoDecoderFactory
-import org.webrtc.SoftwareVideoEncoderFactory
 import org.webrtc.audio.AudioDeviceModule
 import org.webrtc.audio.JavaAudioDeviceModule
 
@@ -56,7 +54,10 @@ class RTCComponentFactory(
                 )
             else ->
                 // context が指定されていなければソフトウェアエンコーダーを使用する
-                SoftwareVideoEncoderFactory()
+                SoraDefaultVideoEncoderFactory(
+                    null,
+                    resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,
+                )
         }
 
         SoraLogger.d(TAG, "videoDecoderFactory => ${mediaOption.videoDecoderFactory}")
@@ -67,7 +68,7 @@ class RTCComponentFactory(
             mediaOption.videoDownstreamContext != null ->
                 DefaultVideoDecoderFactory(mediaOption.videoDownstreamContext)
             else ->
-                SoftwareVideoDecoderFactory()
+                DefaultVideoDecoderFactory(null)
         }
 
         SoraLogger.d(TAG, "decoderFactory => $decoderFactory")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -53,7 +53,6 @@ class RTCComponentFactory(
                     resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,
                 )
             else ->
-                // context が指定されていなければソフトウェアエンコーダーを使用する
                 SoraDefaultVideoEncoderFactory(
                     null,
                     resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,


### PR DESCRIPTION
EglContext が取得できなかった場合に利用する Encoder | Decoder を以下の通り変更しています。

- SoftwareVideoEncoderFactory -> SoraDefaultVideoEncoderFactory
- SoftwareVideoDecoderFactory -> DefaultVideo DecoderFactory

EGLContext は null でも Hardware を使用する MediaCodec は動作するため Software Encoder | Decoderを利用するより Hardware 系も動作する Default Encoder | Decoder を使用して救えるケースを増やす対応です。