### PR TITLE
offer で受信した encodings が反映されない不具合を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 - [FIX] mid を nullable に変更する
     - 「type: offer の mid を必須にする」の対応で role が recvonly の時にエラーとなる不具合の修正
     - @miosakuma
+- [FIX] offer で受信した encodings が反映されない不具合を修正する
+    - @miosakuma
 - [FIX] EGLContext が取れなかった場合、DefaultVideoDecoderFactory, SoraDefaultVideoEncoderFactory を使用する
     - EGLContext が取れなかった場合の Decoder を SoftwareVideoDecoderFactory から DefaultVideoDecoderFactory に変更する
     - EGLContext が取れなかった場合の Encoder を SoftwareVideoEncoderFactory から SoraDefaultVideoEncoderFactory に変更する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -319,13 +319,14 @@ class PeerChannelImpl(
         }
     }
 
-    private fun setTrack(mid: String, track: MediaStreamTrack) {
+    private fun setTrack(mid: String, track: MediaStreamTrack): RtpSender {
         val transceiver = this.conn?.transceivers?.find { it.mid == mid }
         val sender = transceiver!!.sender
         transceiver!!.direction = RtpTransceiver.RtpTransceiverDirection.SEND_ONLY
         sender!!.streams = listOf(localStreamId)
         sender!!.setTrack(track, false)
         SoraLogger.d(TAG, "set ${track.kind()} sender: mid=$mid, transceiver=$transceiver")
+        return sender
     }
 
     override fun handleInitialRemoteOffer(
@@ -354,7 +355,7 @@ class PeerChannelImpl(
 
             mid?.get("video")?.let { mid ->
                 localVideoManager?.track?.let { track ->
-                    setTrack(mid, track)
+                    videoSender = setTrack(mid, track)
                 }
             } ?: SoraLogger.d(TAG, "mid for video not found")
 


### PR DESCRIPTION
https://github.com/shiguredo/sora-android-sdk/commit/03472ef のコミットで videosender に値が設定されなくなり、結果以下の `updateSenderOfferEncodings` が実行されなくなった不具合を修正しました。

https://github.com/shiguredo/sora-android-sdk/compare/feature/fix-update-sender-offer-encodings?expand=1#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cR363
