### PR TITLE
test の role を upstream から sendonly に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] テストコード内に廃止された role が残っていたため最新化する
+    - @miosakuma
+
 ## 2022.4.0
 
 - [CHANGE] type: offer の mid を必須にする

--- a/sora-android-sdk/src/test/kotlin/jp/shiguredo/sora/sdk/ConnectMetadataJsonTest.kt
+++ b/sora-android-sdk/src/test/kotlin/jp/shiguredo/sora/sdk/ConnectMetadataJsonTest.kt
@@ -84,7 +84,7 @@ class ConnectMetadataJsonTest {
 
     private fun roundtrip(metadata: Any?): ConnectMessage {
         val original = ConnectMessage(
-            role = "upstream",
+            role = "sendonly",
             channelId = "sora",
             sdp = "",
             metadata = metadata


### PR DESCRIPTION
テスト内に廃止された role 記載が残っていたので現在の role に変更しました。

テストが成功することについて確認済みです。