### PR TITLE
PeerConnection.ContinualGatheringPolicy の設定を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [FIX] テストコード内に廃止された role が残っていたため最新化する
     - @miosakuma
+- [FIX] `PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY` は Sora がネットワーク変更に対応しておらず不要な設定であるため削除する
+    - @miosakuma
 
 ## 2022.4.0
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerNetworkConfig.kt
@@ -21,7 +21,6 @@ class PeerNetworkConfig(
 
         conf.bundlePolicy = PeerConnection.BundlePolicy.MAXBUNDLE
         conf.rtcpMuxPolicy = PeerConnection.RtcpMuxPolicy.REQUIRE
-        conf.continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
         conf.keyType = PeerConnection.KeyType.ECDSA
         val cryptoOptions = CryptoOptions.builder()
             .setEnableGcmCryptoSuites(true)


### PR DESCRIPTION
PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY の設定はネットワーク変更に対応する設定とあるが、Sora はネットワーク変更に対応していないため不要な設定となっているため削除します。
https://webrtc.googlesource.com/src/+/refs/heads/main/api/peer_connection_interface.h#507