### PR TITLE
[CI] GitHub Actions のバージョンアップ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
           cache: 'gradle'
       - name: Copy gradle.properties

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'


### PR DESCRIPTION
以下 2 点を修正しています。

1. GitHub Actions のバージョンアップ
[CI のワーニング](https://github.com/shiguredo/sora-android-sdk/actions/runs/3406653309) に対する対応です。
Node.js 16 に対応している最新版にしています。ワーニングがなくなったことで OK としています。
2. [CI] JDK の distribution を `adopt` から `temurin` に移行
`adopt` は更新がされなくなるため `temurin` へ移行するようにとのアナウンスに対応したものです。
https://github.com/actions/setup-java#supported-distributions