### PR TITLE
SoraMediaChannel に audioStreamingLanguageCode を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] libwebrtc を 109.5414.2.0 に上げる
     - @miosakuma
+- [ADD] SoraMediaChannel に audioStreamingLanguageCode を追加する
+    - @miosakuma
 - [FIX] テストコード内に廃止された role が残っていたため最新化する
     - @miosakuma
 - [FIX] `PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY` は Sora がネットワーク変更に対応しておらず不要な設定であるため削除する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -67,6 +67,7 @@ import kotlin.concurrent.schedule
  * @param ignoreDisconnectWebSocket connect メッセージに含める `ignore_disconnect_websocket`
  * @param dataChannels connect メッセージに含める `data_channels`
  * @param bundleId connect メッセージに含める `bundle_id`
+ * @param audioStreamingLanguageCode connect メッセージに含める `audio_streaming_language_code`
  */
 class SoraMediaChannel @JvmOverloads constructor(
     private val context: Context,
@@ -84,6 +85,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     ignoreDisconnectWebSocket: Boolean? = null,
     dataChannels: List<Map<String, Any>>? = null,
     private var bundleId: String? = null,
+    private var audioStreamingLanguageCode: String? = null,
 ) {
     companion object {
         private val TAG = SoraMediaChannel::class.simpleName
@@ -634,36 +636,37 @@ class SoraMediaChannel @JvmOverloads constructor(
         SoraLogger.d(
             TAG,
             """connect: SoraMediaOption
-            |requiredRole            = ${mediaOption.requiredRole}
-            |upstreamIsRequired      = ${mediaOption.upstreamIsRequired}
-            |downstreamIsRequired    = ${mediaOption.downstreamIsRequired}
-            |multistreamEnabled      = ${mediaOption.multistreamEnabled}
-            |audioIsRequired         = ${mediaOption.audioIsRequired}
-            |audioUpstreamEnabled    = ${mediaOption.audioUpstreamEnabled}
-            |audioDownstreamEnabled  = ${mediaOption.audioDownstreamEnabled}
-            |audioCodec              = ${mediaOption.audioCodec}
-            |audioBitRate            = ${mediaOption.audioBitrate}
-            |audioSource             = ${mediaOption.audioOption.audioSource}
-            |useStereoInput          = ${mediaOption.audioOption.useStereoInput}
-            |useStereoOutput         = ${mediaOption.audioOption.useStereoOutput}
-            |videoIsRequired         = ${mediaOption.videoIsRequired}
-            |videoUpstreamEnabled    = ${mediaOption.videoUpstreamEnabled}
-            |videoUpstreamContext    = ${mediaOption.videoUpstreamContext}
-            |videoDownstreamEnabled  = ${mediaOption.videoDownstreamEnabled}
-            |videoDownstreamContext  = ${mediaOption.videoDownstreamContext}
-            |videoEncoderFactory     = ${mediaOption.videoEncoderFactory}
-            |videoDecoderFactory     = ${mediaOption.videoDecoderFactory}
-            |videoCodec              = ${mediaOption.videoCodec}
-            |videoBitRate            = ${mediaOption.videoBitrate}
-            |videoCapturer           = ${mediaOption.videoCapturer}
-            |simulcastEnabled        = ${mediaOption.simulcastEnabled}
-            |simulcastRid            = ${mediaOption.simulcastRid}
-            |spotlightEnabled        = ${mediaOption.spotlightEnabled}
-            |spotlightNumber         = ${mediaOption.spotlightOption?.spotlightNumber}
-            |signalingMetadata       = ${this.signalingMetadata}
-            |clientId                = ${this.clientId}
-            |bundleId                = ${this.bundleId}
-            |signalingNotifyMetadata = ${this.signalingNotifyMetadata}
+            |requiredRole               = ${mediaOption.requiredRole}
+            |upstreamIsRequired         = ${mediaOption.upstreamIsRequired}
+            |downstreamIsRequired       = ${mediaOption.downstreamIsRequired}
+            |multistreamEnabled         = ${mediaOption.multistreamEnabled}
+            |audioIsRequired            = ${mediaOption.audioIsRequired}
+            |audioUpstreamEnabled       = ${mediaOption.audioUpstreamEnabled}
+            |audioDownstreamEnabled     = ${mediaOption.audioDownstreamEnabled}
+            |audioCodec                 = ${mediaOption.audioCodec}
+            |audioBitRate               = ${mediaOption.audioBitrate}
+            |audioSource                = ${mediaOption.audioOption.audioSource}
+            |useStereoInput             = ${mediaOption.audioOption.useStereoInput}
+            |useStereoOutput            = ${mediaOption.audioOption.useStereoOutput}
+            |videoIsRequired            = ${mediaOption.videoIsRequired}
+            |videoUpstreamEnabled       = ${mediaOption.videoUpstreamEnabled}
+            |videoUpstreamContext       = ${mediaOption.videoUpstreamContext}
+            |videoDownstreamEnabled     = ${mediaOption.videoDownstreamEnabled}
+            |videoDownstreamContext     = ${mediaOption.videoDownstreamContext}
+            |videoEncoderFactory        = ${mediaOption.videoEncoderFactory}
+            |videoDecoderFactory        = ${mediaOption.videoDecoderFactory}
+            |videoCodec                 = ${mediaOption.videoCodec}
+            |videoBitRate               = ${mediaOption.videoBitrate}
+            |videoCapturer              = ${mediaOption.videoCapturer}
+            |simulcastEnabled           = ${mediaOption.simulcastEnabled}
+            |simulcastRid               = ${mediaOption.simulcastRid}
+            |spotlightEnabled           = ${mediaOption.spotlightEnabled}
+            |spotlightNumber            = ${mediaOption.spotlightOption?.spotlightNumber}
+            |signalingMetadata          = ${this.signalingMetadata}
+            |clientId                   = ${this.clientId}
+            |bundleId                   = ${this.bundleId}
+            |signalingNotifyMetadata    = ${this.signalingNotifyMetadata}
+            |audioStreamingLanguageCode = ${this.audioStreamingLanguageCode}
             """.trimMargin()
         )
 
@@ -772,6 +775,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             bundleId = bundleId,
             signalingNotifyMetadata = signalingNotifyMetadata,
             connectDataChannels = connectDataChannels,
+            audioStreamingLanguageCode = audioStreamingLanguageCode,
             redirect = redirectLocation != null
         )
         signaling!!.connect()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -66,6 +66,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val bundleId: String? = null,
     private val signalingNotifyMetadata: Any? = null,
     private val connectDataChannels: List<Map<String, Any>>? = null,
+    private val audioStreamingLanguageCode: String? = null,
     private val redirect: Boolean = false,
 ) : SignalingChannel {
 
@@ -257,6 +258,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 bundleId = bundleId,
                 signalingNotifyMetadata = signalingNotifyMetadata,
                 dataChannels = connectDataChannels,
+                audioStreamingLanguageCode = audioStreamingLanguageCode,
                 redirect = redirect
             )
             it.send(message)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -46,6 +46,7 @@ data class ConnectMessage(
     @SerializedName("ignore_disconnect_websocket")
     val ignoreDisconnectWebsocket: Boolean? = null,
     @SerializedName("data_channels") val dataChannels: List<Map<String, Any>>? = null,
+    @SerializedName("audio_streaming_language_code") val audioStreamingLanguageCode: String? = null,
     @SerializedName("redirect") var redirect: Boolean? = null
 )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -39,6 +39,7 @@ class MessageConverter {
             bundleId: String? = null,
             signalingNotifyMetadata: Any? = null,
             dataChannels: List<Map<String, Any>>? = null,
+            audioStreamingLanguageCode: String?,
             redirect: Boolean = false
         ): String {
 
@@ -48,6 +49,7 @@ class MessageConverter {
                 dataChannelSignaling = dataChannelSignaling,
                 ignoreDisconnectWebsocket = ignoreDisconnectWebSocket,
                 dataChannels = dataChannels,
+                audioStreamingLanguageCode = audioStreamingLanguageCode,
                 metadata = metadata,
                 multistream = mediaOption.multistreamIsRequired,
                 sdp = sdp,


### PR DESCRIPTION
Sora Android SDK に `audio_streaming_language_code` を追加する対応です。
https://sora-doc.shiguredo.jp/AUDIO_STREAMING#a8b9a3

動作確認は以下を確認しています。

- [x] audio_streaming_language_code 未指定で動作すること、項目が送信されないこと
- [x] audio_streaming_language_code 指定時に送信がされること

項目の並び順に迷いつつ追加しています。気になることあればぜひコメントをお願いします。