### PR TITLE
SoraMediaOption に audioStreamingLanguageCode を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] libwebrtc を 109.5414.2.0 に上げる
     - @miosakuma
+- [ADD] SoraMediaOption に audioStreamingLanguageCode を追加する
+    - @miosakuma
 - [FIX] テストコード内に廃止された role が残っていたため最新化する
     - @miosakuma
 - [FIX] `PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY` は Sora がネットワーク変更に対応しておらず不要な設定であるため削除する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -665,7 +665,6 @@ class SoraMediaChannel @JvmOverloads constructor(
             |clientId                   = ${this.clientId}
             |bundleId                   = ${this.bundleId}
             |signalingNotifyMetadata    = ${this.signalingNotifyMetadata}
-            ""${'"'}.trimMargin()
             """.trimMargin()
         )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -634,36 +634,38 @@ class SoraMediaChannel @JvmOverloads constructor(
         SoraLogger.d(
             TAG,
             """connect: SoraMediaOption
-            |requiredRole            = ${mediaOption.requiredRole}
-            |upstreamIsRequired      = ${mediaOption.upstreamIsRequired}
-            |downstreamIsRequired    = ${mediaOption.downstreamIsRequired}
-            |multistreamEnabled      = ${mediaOption.multistreamEnabled}
-            |audioIsRequired         = ${mediaOption.audioIsRequired}
-            |audioUpstreamEnabled    = ${mediaOption.audioUpstreamEnabled}
-            |audioDownstreamEnabled  = ${mediaOption.audioDownstreamEnabled}
-            |audioCodec              = ${mediaOption.audioCodec}
-            |audioBitRate            = ${mediaOption.audioBitrate}
-            |audioSource             = ${mediaOption.audioOption.audioSource}
-            |useStereoInput          = ${mediaOption.audioOption.useStereoInput}
-            |useStereoOutput         = ${mediaOption.audioOption.useStereoOutput}
-            |videoIsRequired         = ${mediaOption.videoIsRequired}
-            |videoUpstreamEnabled    = ${mediaOption.videoUpstreamEnabled}
-            |videoUpstreamContext    = ${mediaOption.videoUpstreamContext}
-            |videoDownstreamEnabled  = ${mediaOption.videoDownstreamEnabled}
-            |videoDownstreamContext  = ${mediaOption.videoDownstreamContext}
-            |videoEncoderFactory     = ${mediaOption.videoEncoderFactory}
-            |videoDecoderFactory     = ${mediaOption.videoDecoderFactory}
-            |videoCodec              = ${mediaOption.videoCodec}
-            |videoBitRate            = ${mediaOption.videoBitrate}
-            |videoCapturer           = ${mediaOption.videoCapturer}
-            |simulcastEnabled        = ${mediaOption.simulcastEnabled}
-            |simulcastRid            = ${mediaOption.simulcastRid}
-            |spotlightEnabled        = ${mediaOption.spotlightEnabled}
-            |spotlightNumber         = ${mediaOption.spotlightOption?.spotlightNumber}
-            |signalingMetadata       = ${this.signalingMetadata}
-            |clientId                = ${this.clientId}
-            |bundleId                = ${this.bundleId}
-            |signalingNotifyMetadata = ${this.signalingNotifyMetadata}
+            |requiredRole               = ${mediaOption.requiredRole}
+            |upstreamIsRequired         = ${mediaOption.upstreamIsRequired}
+            |downstreamIsRequired       = ${mediaOption.downstreamIsRequired}
+            |multistreamEnabled         = ${mediaOption.multistreamEnabled}
+            |audioIsRequired            = ${mediaOption.audioIsRequired}
+            |audioUpstreamEnabled       = ${mediaOption.audioUpstreamEnabled}
+            |audioDownstreamEnabled     = ${mediaOption.audioDownstreamEnabled}
+            |audioCodec                 = ${mediaOption.audioCodec}
+            |audioBitRate               = ${mediaOption.audioBitrate}
+            |audioSource                = ${mediaOption.audioOption.audioSource}
+            |useStereoInput             = ${mediaOption.audioOption.useStereoInput}
+            |useStereoOutput            = ${mediaOption.audioOption.useStereoOutput}
+            |videoIsRequired            = ${mediaOption.videoIsRequired}
+            |videoUpstreamEnabled       = ${mediaOption.videoUpstreamEnabled}
+            |videoUpstreamContext       = ${mediaOption.videoUpstreamContext}
+            |videoDownstreamEnabled     = ${mediaOption.videoDownstreamEnabled}
+            |videoDownstreamContext     = ${mediaOption.videoDownstreamContext}
+            |videoEncoderFactory        = ${mediaOption.videoEncoderFactory}
+            |videoDecoderFactory        = ${mediaOption.videoDecoderFactory}
+            |videoCodec                 = ${mediaOption.videoCodec}
+            |videoBitRate               = ${mediaOption.videoBitrate}
+            |videoCapturer              = ${mediaOption.videoCapturer}
+            |simulcastEnabled           = ${mediaOption.simulcastEnabled}
+            |simulcastRid               = ${mediaOption.simulcastRid}
+            |spotlightEnabled           = ${mediaOption.spotlightEnabled}
+            |spotlightNumber            = ${mediaOption.spotlightOption?.spotlightNumber}
+            |audioStreamingLanguageCode = ${mediaOption.audioStreamingLanguageCode}
+            |signalingMetadata          = ${this.signalingMetadata}
+            |clientId                   = ${this.clientId}
+            |bundleId                   = ${this.bundleId}
+            |signalingNotifyMetadata    = ${this.signalingNotifyMetadata}
+            ""${'"'}.trimMargin()
             """.trimMargin()
         )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -237,4 +237,9 @@ class SoraMediaOption {
      * プロキシ
      */
     var proxy: SoraProxyOption = SoraProxyOption()
+
+    /**
+     * Sora の音声ストリーミング機能利用時に指定する言語コード
+     */
+    var audioStreamingLanguageCode: String? = null
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -46,6 +46,8 @@ data class ConnectMessage(
     @SerializedName("ignore_disconnect_websocket")
     val ignoreDisconnectWebsocket: Boolean? = null,
     @SerializedName("data_channels") val dataChannels: List<Map<String, Any>>? = null,
+    @SerializedName("audio_streaming_language_code")
+    val audioStreamingLanguageCode: String? = null,
     @SerializedName("redirect") var redirect: Boolean? = null
 )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -54,6 +54,7 @@ class MessageConverter {
                 clientId = clientId,
                 bundleId = bundleId,
                 signalingNotifyMetadata = signalingNotifyMetadata,
+                audioStreamingLanguageCode = mediaOption.audioStreamingLanguageCode,
             )
 
             if (mediaOption.upstreamIsRequired) {


### PR DESCRIPTION
https://github.com/shiguredo/sora-android-sdk/pull/90 にて SoraMediaOption に `audioStreamingLanguageCode` を追加することになったので再作成をしました。

動作確認は以下を確認しています。

- [x] audio_streaming_language_code 未指定で動作すること、項目が送信されないこと
- [x] audio_streaming_language_code 指定時に送信がされること