### PR TITLE
テストロジック内に upstream の role が残っていたため修正する

### DIFF
--- a/sora-android-sdk/src/test/kotlin/jp/shiguredo/sora/sdk/ConnectClientIdTest.kt
+++ b/sora-android-sdk/src/test/kotlin/jp/shiguredo/sora/sdk/ConnectClientIdTest.kt
@@ -25,7 +25,7 @@ class ConnectClientIdTest {
 
     private fun roundtrip(clientId: String?): Map<*, *> {
         val original = ConnectMessage(
-            role = "upstream",
+            role = "sendonly",
             channelId = "sora",
             sdp = "",
             clientId = clientId


### PR DESCRIPTION
テストロジック内に role upstream が残っていたため現在の role である sendonly に書き換えました。
テストの正常終了を確認しています。

修正漏れであり、CHANGES はすでに記載済みです。