### PR TITLE
simulcast を offer の内容で上書きする

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -812,7 +812,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             }
         }
         peer?.run {
-            val subscription = handleInitialRemoteOffer(offerMessage.sdp, offerMessage.mid, offerMessage.encodings)
+            val subscription = handleInitialRemoteOffer(offerMessage.sdp, offerMessage.mid, offerMessage.simulcast, offerMessage.encodings)
                 .observeOn(Schedulers.io())
                 .subscribeBy(
                     onSuccess = {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -38,6 +38,7 @@ interface PeerChannel {
     fun handleInitialRemoteOffer(
         offer: String,
         mid: Map<String, String>?,
+        simulcast: Boolean?,
         encodings: List<Encoding>?
     ): Single<SessionDescription>
     fun handleUpdatedRemoteOffer(offer: String): Single<SessionDescription>
@@ -332,10 +333,13 @@ class PeerChannelImpl(
     override fun handleInitialRemoteOffer(
         offer: String,
         mid: Map<String, String>?,
+        simulcast: Boolean?,
         encodings: List<Encoding>?
     ): Single<SessionDescription> {
         val offerSDP = SessionDescription(SessionDescription.Type.OFFER, offer)
         offerEncodings = encodings
+
+        mediaOption.simulcastEnabled = simulcast ?: false
 
         return setup().flatMap {
             SoraLogger.d(TAG, "setRemoteDescription")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -106,6 +106,7 @@ data class OfferMessage(
     @SerializedName("metadata") val metadata: Any?,
     @SerializedName("config") val config: OfferConfig? = null,
     @SerializedName("mid") val mid: Map<String, String>? = null,
+    @SerializedName("simulcast") val simulcast: Boolean? = false,
     @SerializedName("encodings") val encodings: List<Encoding>?,
     @SerializedName("data_channels") val dataChannels: List<Map<String, Any>>? = null
 )


### PR DESCRIPTION
auth webhook から simulcast を true に設定した場合に映像が 3 本とならない不具合がありました。

この PR にて offer の simulcast の内容で上書きを行うことで事象は改善しています。
バリエーションについてはこれから試験をしますが、対応の方法に問題ないかご確認いただけますでしょうか。

