### PR TITLE
VideoCodec に AV1 を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
     - @miosakuma
 - [UPDATE] libwebrtc を 111.5563.0.0 に上げる
     - @miosakuma
+- [UPDATE] 映像コーデックに AV1 を追加する
+    - @miosakuma
 - [ADD] SoraMediaOption に audioStreamingLanguageCode を追加する
     - @miosakuma
 - [FIX] テストコード内に廃止された role が残っていたため最新化する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -16,7 +16,9 @@ class SoraVideoOption {
         /** VP8 */
         VP8,
         /** VP9 */
-        VP9
+        VP9,
+        /** AV1 */
+        AV1
     }
 
     /**


### PR DESCRIPTION
libwebrtc 111.5563.0.0 で AV1 が動作するようになりました。Video Codec のオプションに AV1 を追加します。