### PR TITLE
toLowerCase(Locale) が deprecated となったため lowercase() に書き換える

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraChannelRole.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraChannelRole.kt
@@ -1,7 +1,5 @@
 package jp.shiguredo.sora.sdk.channel.option
 
-import java.util.Locale
-
 /**
  * チャネルの役割を示します.
  */
@@ -17,5 +15,5 @@ enum class SoraChannelRole {
     SENDRECV;
 
     internal val signaling: String
-        get() = this.toString().toLowerCase(Locale.getDefault())
+        get() = this.toString().lowercase()
 }


### PR DESCRIPTION
SDK のビルド時に以下のワーニングが出ており、内容的に問題ないので変更しました。

`toLowerCase(Locale): String' is deprecated. Use lowercase() instead.`