### PR TITLE
scalability mode に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [ADD]
+  - scalability mode に対応する
+  - VP9 / AV1 のサイマルキャストに対応可能になる
+  - @szktty
+
 ## 2023.1.0
 
 - [UPDATE] システム条件を更新する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -385,6 +385,7 @@ class PeerChannelImpl(
             offerEncoding.maxBitrate?.also { senderEncoding.maxBitrateBps = it }
             offerEncoding.maxFramerate?.also { senderEncoding.maxFramerate = it }
             offerEncoding.scaleResolutionDownBy?.also { senderEncoding.scaleResolutionDownBy = it }
+            offerEncoding.scalabilityMode?.also { senderEncoding.scalabilityMode = it }
         }
 
         // アプリケーションに一旦渡す, encodings は final なので参照渡しで変更してもらう
@@ -398,6 +399,7 @@ class PeerChannelImpl(
                         "rid=$rid, " +
                         "active=$active, " +
                         "scaleResolutionDownBy=$scaleResolutionDownBy, " +
+                        "scalabilityMode=$scalabilityMode, " +
                         "maxFramerate=$maxFramerate, " +
                         "maxBitrateBps=$maxBitrateBps, " +
                         "ssrc=$ssrc"

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -90,7 +90,8 @@ data class Encoding(
     @SerializedName("active") val active: Boolean?,
     @SerializedName("maxBitrate") val maxBitrate: Int?,
     @SerializedName("maxFramerate") val maxFramerate: Int?,
-    @SerializedName("scaleResolutionDownBy") val scaleResolutionDownBy: Double?
+    @SerializedName("scaleResolutionDownBy") val scaleResolutionDownBy: Double?,
+    @SerializedName("scalabilityMode") val scalabilityMode: String?
 )
 
 data class RedirectMessage(


### PR DESCRIPTION
**NOTE: 本 PR は scalability mode 対応のパッチを適用した webrtc-build のバイナリが必要になります。現在の指定のバージョンでは動作しません。**

scalability mode に対応します。 scalability 対応の webrtc-build を利用すると、 VP9 と AV1 のサイマルキャストにも対応します。
