### PR TITLE
接続時の映像コーデックパラメータを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,10 +15,12 @@
     - @miosakuma
 - [ADD] 転送フィルター機能を追加する
     - @szktty
-- [ADD]
-  - scalability mode に対応する
+- [ADD] scalability mode に対応する
   - VP9 / AV1 のサイマルキャストに対応可能になる
   - @szktty
+- [ADD] 映像コーデックパラメータを追加する
+    - `SoraMediaOption` に `videoVp9Params`, `videoAv1Params`, `videoH264Params` を追加する
+    - @miosakuma
 
 ## 2023.1.0
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -658,6 +658,9 @@ class SoraMediaChannel @JvmOverloads constructor(
             |videoDecoderFactory        = ${mediaOption.videoDecoderFactory}
             |videoCodec                 = ${mediaOption.videoCodec}
             |videoBitRate               = ${mediaOption.videoBitrate}
+            |videoVp9Params             = ${mediaOption.videoVp9Params}
+            |videoAv1Params             = ${mediaOption.videoAv1Params}
+            |videoH264Params            = ${mediaOption.videoH264Params}
             |videoCapturer              = ${mediaOption.videoCapturer}
             |simulcastEnabled           = ${mediaOption.simulcastEnabled}
             |simulcastRid               = ${mediaOption.simulcastRid}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -42,8 +42,16 @@ class SoraMediaOption {
     internal var videoDownstreamContext: EglBase.Context? = null
     internal var videoUpstreamContext: EglBase.Context? = null
 
+    /**
+     * 映像コーデック.
+     *
+     * 未設定の場合、 Sora Android SDK は VP9 を設定します.
+     */
     var videoCodec = SoraVideoOption.Codec.VP9
 
+    /**
+     * 映像ビットレート.
+     */
     // videoBitRate が正しい綴りだが後方互換性を壊すほどではないので放置する
     var videoBitrate: Int? = null
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -56,6 +56,21 @@ class SoraMediaOption {
     var videoBitrate: Int? = null
 
     /**
+     * VP9 向け映像コーデックパラメーター.
+     */
+    var videoVp9Params: Any? = null
+
+    /**
+     * AV1 向け映像コーデックパラメーター.
+     */
+    var videoAv1Params: Any? = null
+
+    /**
+     * H.264 向け映像コーデックパラメーター.
+     */
+    var videoH264Params: Any? = null
+
+    /**
      * 映像の視聴を有効にします.
      *
      * cf.

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -54,7 +54,10 @@ data class ConnectMessage(
 
 data class VideoSetting(
     @SerializedName("codec_type") val codecType: String,
-    @SerializedName("bit_rate") var bitRate: Int? = null
+    @SerializedName("bit_rate") var bitRate: Int? = null,
+    @SerializedName("vp9_params") var vp9Params: Any? = null,
+    @SerializedName("av1_params") var av1Params: Any? = null,
+    @SerializedName("h264_params") var h264Params: Any? = null
 )
 
 data class AudioSetting(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -77,6 +77,9 @@ class MessageConverter {
                 if (mediaOption.videoUpstreamEnabled) {
                     val videoSetting = VideoSetting(mediaOption.videoCodec.toString())
                     mediaOption.videoBitrate?.let { videoSetting.bitRate = it }
+                    mediaOption.videoVp9Params?.let { videoSetting.vp9Params = it }
+                    mediaOption.videoAv1Params?.let { videoSetting.av1Params = it }
+                    mediaOption.videoH264Params?.let { videoSetting.h264Params = it }
                     msg.video = videoSetting
                 } else {
                     msg.video = false


### PR DESCRIPTION
`SoraMediaOption` に `videoVp9Params`, `videoAv1Params`, `videoH264Params` を追加しました。

sora-android-quickstart を利用して値を設定するイメージは以下です。

```
        option.videoCodec = SoraVideoOption.Codec.VP9
        option.videoVp9Params = object {
            var profile_id: Int = 0
        }
//        option.videoCodec = SoraVideoOption.Codec.AV1
//        option.videoAv1Params = object {
//            var profile: Int = 0
//        }

//        option.videoCodec = SoraVideoOption.Codec.H264
//        option.videoH264Params = object {
//            var profile_level_id: String = "42e034"
//        }
```

同様の修正が入った sora-android-quickstart のブランチが以下にあります。
https://github.com/shiguredo/sora-android-sdk-quickstart/tree/test/add-video-codec-params