### PR TITLE
libwebrtc を 121.6167.4.0 に上げる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '18'
           cache: 'gradle'
       - name: Copy gradle.properties
         run: cp gradle.properties.example gradle.properties

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@
 - [CHANGE] NotificationMessage の channel_id を削除する
   - Sora から値を通知しておらず利用していない項目のため削除する
   - @miosakuma
-- [UPDATE] libwebrtc を 119.6045.2.1 に上げる
+- [UPDATE] libwebrtc を 121.6167.4.0 に上げる
+  - コンバイルに利用する Java のバージョンを 1.8 に上げる
   - @miosakuma
 - [UPDATE] 解像度に qHD (960x540, 540x960) を追加する
   - @enm10k

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.libwebrtc_version = '119.6045.2.1'
+    ext.libwebrtc_version = '121.6167.4.0'
 
     ext.dokka_version = '1.8.10'
 

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -31,8 +31,8 @@ android {
         release {
         }
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
         }
     }
 


### PR DESCRIPTION
以下のエラーに対応してコンバイルに利用する Java のバージョンを 1.8 にあげています。
`Invoke-customs are only supported starting with Android O (--min-api 26)`