### PR TITLE
jitpack.yml ファイルを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [FIX] jitpack.yml を追加して jdk のバージョンを 11 に指定する
+  - JitPack で jdk 8 でビルドが走ってエラーとなったため、明示的に利用する jdk を指定する
+  - @miosakuma
+
 ## 2024.1.0
 
 - [CHANGE] `NotificationMessage` の `matadata_list` を削除する

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Sora Android SDK 2024.1.0 リリース時に JitPack で Sora Android SDK をビルドする際に `openjdk version "1.8.0_252"` が利用されビルドエラーが発生する事象が発生しました。

- エラーとなったビルドログ（規定時間でリンクが切れます）
https://github.com/jitpack/jitpack.io/issues/new/choose?title=sora-android-sdk/2024.1.0%20build

2023.2.0 リリースでは `openjdk version "11.0.2"` が選択されたためビルドに成功していました。

jitpack.yml で明示的に jdk のバージョンを指定できるため、`openjdk11` を指定し、ビルドが通りました。

- 成功したビルドログ（規定時間でリンクが切れます）
https://jitpack.io/com/github/shiguredo/sora-android-sdk/feature~fix-jitpack-error-2021.1-g092f4af-476/build.log

今後は明示的に jdk を指定するようにしようと思います。
