### PR TITLE
[CI] actions/setup-java@v4 にあげる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '18'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] Github Actions の actions/setup-java@v4 にあげる
+  - @miosakuma
+
 ## 2024.1.1
 
 - [FIX] jitpack.yml を追加して jdk のバージョンを 11 に指定する


### PR DESCRIPTION
 Github Actions の Node.js 16 の廃止に伴い Node.js 20 を利用した action に変更します。