### PR TITLE
GitHub Actions の起動イベントに workflow_dispatch を追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - 'README.md'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] libwebrtc を 125.6422.2.5 に上げる
   - @miosakuma
+- [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
+  - @zztkm
 
 ## 2024.2.0
 


### PR DESCRIPTION
- [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加

---

This pull request includes changes to the GitHub Actions workflow and the project's change log. The most significant changes are the addition of the `workflow_dispatch` event to the GitHub Actions workflow and the corresponding update to the change log.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R4): Added the `workflow_dispatch` event to the GitHub Actions workflow. This allows the workflow to be manually triggered from the GitHub Actions UI.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R17): Updated the change log to reflect the addition of the `workflow_dispatch` event to the GitHub Actions workflow.