### PR TITLE
offer メッセージの simulcast を利用する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
     - [libwebrtc の定義](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/sdk/android/api/org/webrtc/RtpParameters.java;l=72-73;drc=02334e07c5c04c729dd3a8a279bb1fbe24ee8b7c)
   - @torikizi
 - [FIX] Offer メッセージでサイマルキャスト有効を指定した場合にサイマルキャストが有効にならない問題を修正
-  - 接続時にクライアントが指定したサイマルキャスト有効/無効の設定により SimulcastVideoEncoder を利用していたが、Sora 側でサイマルキャスト有効の指定は変更できるためサイマルキャスト有効/無効の判断は Offer で行う必要があった
+  - 接続時にクライアントが指定したサイマルキャスト有効/無効の設定により SimulcastVideoEncoder を利用していたが、Sora 側でサイマルキャスト有効の指定は変更できるためサイマルキャスト有効/無効の判断は Offer メッセージの `simulcast` の値を元に行う必要があった
 
 ## 2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
     - [W3C の定義](https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-maxframerate)
     - [libwebrtc の定義](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/sdk/android/api/org/webrtc/RtpParameters.java;l=72-73;drc=02334e07c5c04c729dd3a8a279bb1fbe24ee8b7c)
   - @torikizi
+- [FIX] Offer メッセージでサイマルキャスト有効を指定した場合にサイマルキャストが有効にならない問題を修正
+  - 接続時にクライアントが指定したサイマルキャスト有効/無効の設定により SimulcastVideoEncoder を利用していたが、Sora 側でサイマルキャスト有効の指定は変更できるためサイマルキャスト有効/無効の判断は Offer で行う必要があった
 
 ## 2024.2.0
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -797,6 +797,7 @@ class SoraMediaChannel @JvmOverloads constructor(
                 mediaOption = mediaOption
             ),
             mediaOption = mediaOption,
+            simulcastEnabled = offerMessage.simulcast,
             dataChannelConfigs = offerMessage.dataChannels,
             listener = peerListener
         )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -79,6 +79,7 @@ class PeerChannelImpl(
     private val appContext: Context,
     private val networkConfig: PeerNetworkConfig,
     private val mediaOption: SoraMediaOption,
+    private val simulcastEnabled: Boolean = false,
     dataChannelConfigs: List<Map<String, Any>>? = null,
     private var listener: PeerChannel.Listener?,
     private var useTracer: Boolean = false
@@ -104,7 +105,7 @@ class PeerChannelImpl(
         }
     }
 
-    private val componentFactory = RTCComponentFactory(mediaOption, listener)
+    private val componentFactory = RTCComponentFactory(mediaOption, simulcastEnabled, listener)
 
     private var conn: PeerConnection? = null
 
@@ -309,7 +310,7 @@ class PeerChannelImpl(
 
         return setRemoteDescription(offerSDP).flatMap {
             // active: false が無効化されてしまう問題に対応
-            if (mediaOption.simulcastEnabled && mediaOption.videoUpstreamEnabled) {
+            if (simulcastEnabled && mediaOption.videoUpstreamEnabled) {
                 videoSender?.let { updateSenderOfferEncodings(it) }
             }
             return@flatMap createAnswer()
@@ -359,7 +360,7 @@ class PeerChannelImpl(
                 }
             } ?: SoraLogger.d(TAG, "mid for video not found")
 
-            if (mediaOption.simulcastEnabled && mediaOption.videoUpstreamEnabled) {
+            if (simulcastEnabled && mediaOption.videoUpstreamEnabled) {
                 videoSender?.let { updateSenderOfferEncodings(it) }
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -14,6 +14,7 @@ import org.webrtc.audio.JavaAudioDeviceModule
 
 class RTCComponentFactory(
     private val mediaOption: SoraMediaOption,
+    private val simulcastEnabled: Boolean,
     private val listener: PeerChannel.Listener?
 ) {
     companion object {
@@ -36,7 +37,7 @@ class RTCComponentFactory(
         val encoderFactory = when {
             mediaOption.videoEncoderFactory != null ->
                 mediaOption.videoEncoderFactory!!
-            mediaOption.simulcastEnabled ->
+            simulcastEnabled ->
                 SimulcastVideoEncoderFactoryWrapper(
                     mediaOption.videoUpstreamContext,
                     resolutionAdjustment = mediaOption.hardwareVideoEncoderResolutionAdjustment,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -108,6 +108,7 @@ data class OfferMessage(
     @SerializedName("client_id") val clientId: String,
     @SerializedName("bundle_id") val bundleId: String? = null,
     @SerializedName("connection_id") val connectionId: String,
+    @SerializedName("simulcast") val simulcast: Boolean = false,
     @SerializedName("metadata") val metadata: Any?,
     @SerializedName("config") val config: OfferConfig? = null,
     @SerializedName("mid") val mid: Map<String, String>? = null,


### PR DESCRIPTION
動作確認が完了して、コメントもいただけたので正式 PR に変更しました（2024/08/06）。


対応内容
---

simulcast について connect でクライアントから払い出した値を認証ウェブフックで 上書きしても
クライアントに反映されない不具合を修正した。
ユーザーから指定された simulcast を利用していたので offer メッセージから取得した simulcast を利用するように修正した。

過去の相談内容
---

offer で取得した simulcast の値を EncoderFactory まで引き回すように各種引数を追加したが、この対応で問題ないか。
現在ユーザが設定した接続オプション(MediaOption) をそのままコア部分まで渡しているがそこから抜本的に変えた方がよいか。

修正経緯として、はじめは https://github.com/shiguredo/sora-android-sdk/pull/93 にて MediaOption の simulcastEnabled を offer の値で上書きしていましたが、
ユーザが設定した接続オプションを SDK 側で書き換えるのはよくない、という指摘を受け、MediaOption を更新しない書き方で対応しています。
https://github.com/shiguredo/sora-android-sdk/pull/93#issuecomment-1384738516

### 現在の接続の流れ

関係ない項目は割愛していますが、以下のような内容です。

1. ユーザが MediaOption に接続オプションを設定（simulcast, role, proxy 設定など）
2. ユーザは MediaOption を引数に SoraMediaChannel を作成する
3. ユーザは SoraMediaChannel の connect() を呼ぶ
4. SoraMediaChannel は接続開始までに必要な操作を行う
    1. SoraMediaChannel は connect を Sora に投げる
        - SDP 生成するために MediaOption を引数に PeerChannel を生成する
        - PeerChannle 生成時に MediaOption を引数に RTCComponentFactory が生成され Encoder を設定する
    2. SoraMediaChannel は offer 受信後 answer を生成し Sora に投げる
        - 通話に利用するために MediaOption を引数に PeerChannel を生成する
        - PeerChannle 生成時に MediaOption を引数に RTCComponentFactory が生成され Encoder を設定する
5. Sora との接続が確立

### 修正後の接続の流れ

4 の処理について PeerChannel, RTCComponentFactory のコンストラクタ引数に simulcastEnabled を追加しています。

1. ユーザが MediaOption に接続オプションを設定（simulcast, role, proxy 設定など）
2. ユーザは MediaOption を引数に SoraMediaChannel を作成する
3. ユーザは SoraMediaChannel の connect() を呼ぶ
4. SoraMediaChannel は接続開始までに必要な操作を行う
    1. SoraMediaChannel は connect を Sora に投げる
        - SDP 生成するために MediaOption **と simulcastEnabled** を引数に PeerChannel を生成する
        - PeerChannle 生成時に MediaOption **と simulcastEnabled** を引数に RTCComponentFactory が生成され Encoder を設定する
    2. SoraMediaChannel は offer 受信後 answer を生成し Sora に投げる
        - 通話に利用するために MediaOption **と simulcastEnabled** を引数に PeerChannel を生成する
        - PeerChannle 生成時に MediaOption **と simulcastEnabled** を引数に RTCComponentFactory が生成され Encoder を設定する
5. Sora との接続が確立

そもそも MediaOption が最後まで連携されるのはおかしい、MediaOption + simulcastEnabled の値を持った別の構造体を用意すべき、という意見もあるかなと思い、対応内容がこれでよかったかコメントをもらえるとうれしいです。

---

This pull request primarily focuses on adding simulcast support to the `SoraMediaChannel` and `PeerChannelImpl` classes in the `sora-android-sdk` project. The changes include adding a new `simulcastEnabled` parameter to several methods and classes, and replacing the use of `mediaOption.simulcastEnabled` with this new parameter. 

Changes related to `simulcastEnabled`:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R800): Added `simulcastEnabled` as a parameter to the `SoraMediaChannel` constructor.
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt`](diffhunk://#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cR82): Added `simulcastEnabled` as a parameter to the `PeerChannelImpl` constructor and replaced `mediaOption.simulcastEnabled` with `simulcastEnabled` in several places. [[1]](diffhunk://#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cR82) [[2]](diffhunk://#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cL107-R108) [[3]](diffhunk://#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cL312-R313) [[4]](diffhunk://#diff-22fffda1f1ce986727680846cce81c9d0c467acb07bb4cdf1ef637df4b01c74cL362-R363)
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt`](diffhunk://#diff-ec7cb7f211743e5948b6d5d531a1ce11fcbed7076a4315d896e7efdbb8865e3cR17): Added `simulcastEnabled` as a parameter to the `RTCComponentFactory` constructor and replaced `mediaOption.simulcastEnabled` with `simulcastEnabled`. [[1]](diffhunk://#diff-ec7cb7f211743e5948b6d5d531a1ce11fcbed7076a4315d896e7efdbb8865e3cR17) [[2]](diffhunk://#diff-ec7cb7f211743e5948b6d5d531a1ce11fcbed7076a4315d896e7efdbb8865e3cL39-R40)

Changes related to `OfferMessage`:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880R111): Added `simulcast` as a serialized field to the `OfferMessage` data class.