### PR TITLE
GitHub Actions の定期実行をやめる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
       - 'CHANGES.md'
       - 'LICENSE'
       - 'THANKS'
-  schedule:
-    # UTC の 01:00 は JST だと 10:00 。
-    # 1-5 で 月曜日から金曜日
-    - cron: "0 1 * * 1-5"
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   - @miosakuma
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
+- [UPDATE] GitHub Actions の定期実行をやめる
+  - build.yml の起動イベントから schedule を削除
+  - @zztkm
 - [FIX] Offer メッセージの encodings 内 maxFramerate の値が整数でない値であった場合にエラーとなる問題を修正
   - W3C では maxFramerate を Double で定義しているが、libwebrtc では Integer となっているため、SDK も Integer を使用していた
   - W3C の定義に合わせて Double を受け入れるようにし、また SDK 内部では libwebrtc に合わせて Integer とする方針となった


### PR DESCRIPTION
変更内容

- [UPDATE] GitHub Actions の定期実行をやめる
  - build.yml の起動イベントから schedule を削除

---

This pull request mainly includes changes related to the scheduling of GitHub Actions. The most significant change is the removal of the scheduled execution of GitHub Actions, which is reflected in both the `build.yml` file and the `CHANGES.md` file.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-L14): The `schedule` field under the `on:` key has been removed, which means that GitHub Actions will no longer run on a schedule.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R18-R20): A new entry has been added to the changelog to document the removal of scheduled execution of GitHub Actions.