### PR TITLE
libwebrtc を 127.6533.1.1 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@
 
 ## develop
 
-- [UPDATE] libwebrtc を 125.6422.2.5 に上げる
+- [UPDATE] libwebrtc を 127.6533.1.1 に上げる
   - @miosakuma
+  - @zztkm
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sora Android SDK
 
 [![Release](https://jitpack.io/v/shiguredo/sora-android-sdk.svg)](https://jitpack.io/#shiguredo/sora-android-sdk)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-125.6422-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6422)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-127.6533-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6533)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/shiguredo/sora-android-sdk.svg)](https://github.com/shiguredo/sora-android-sdk.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.libwebrtc_version = '127.6433.1.1'
+    ext.libwebrtc_version = '127.6533.1.1'
 
     ext.dokka_version = '1.8.10'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.libwebrtc_version = '125.6422.2.5'
+    ext.libwebrtc_version = '127.6433.1.1'
 
     ext.dokka_version = '1.8.10'
 


### PR DESCRIPTION
変更内容

- [UPDATE] libwebrtc を 127.6533.1.1 に上げる

---

This pull request includes updates to the `libwebrtc` version and documentation changes to reflect this update.

### Version Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R16): Updated `libwebrtc` version from `125.6422.2.5` to `127.6533.1.1`. (@miosakuma, @zztkm)

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated the `libwebrtc` badge to reflect the new version `127.6533`.