### PR TITLE
2025 年 6 月リリースでレガシー ストリーム機能が削除される予定のため、enableMultistream() を非推奨にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - [UPDATE] libwebrtc を 127.6533.1.1 に上げる
   - @miosakuma
   - @zztkm
+- [UPDATE] `SoraMediaOption.enableMultistream()` を非推奨にする
+  - Sora のレガシーストリーム機能が 2025 年 6 月リリースにて廃止されるため
+  - @zztkm
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -172,6 +172,9 @@ class SoraMediaOption {
      * - Sora ドキュメントのマルチストリーム
      *   [](https://sora.shiguredo.jp/doc/MULTISTREAM.html)
      */
+    @Deprecated(
+        message = "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。"
+    )
     fun enableMultistream() {
         multistreamEnabled = true
     }


### PR DESCRIPTION
変更内容

- [UPDATE] `SoraMediaOption.enableMultistream()` を非推奨にする
  - Sora のレガシーストリーム機能が 2025 年 6 月リリースにて廃止されるため

---

This pull request includes changes to deprecate a method and update the documentation accordingly. The most important changes include marking the `SoraMediaOption.enableMultistream()` method as deprecated and updating the `CHANGES.md` file to reflect this deprecation.

Deprecation of method:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt`](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427R175-R177): Marked the `enableMultistream()` method as deprecated with a message indicating the feature will be removed in the June 2025 release.

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R17-R19): Added an entry to indicate that the `SoraMediaOption.enableMultistream()` method is deprecated due to the upcoming removal of the legacy stream feature in June 2025.