### PR TITLE
Android Gradle Plugin を 8.5.0 にアップグレード

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '18'
+          # java-version を 17 にしている理由は以下です
+          # - Android Gradle plugin 8.5 のデフォルト JDK version が 17
+          # - 17 は LTS であり、temurin では 2027年10月までサポート予定
+          java-version: '17'
           cache: 'gradle'
       - name: Copy gradle.properties
         run: cp gradle.properties.example gradle.properties

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
       - classifier は Gradle 8.0 で削除された
       - https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
     - compileSdkVersion と targetSdkVersion を 34 に上げる
+  - GitHub Actions で利用する JDK のバージョンを 17 にする
+  - JitPack でのビルドで利用する JDK のバージョンを 17 にする
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,19 @@
 - [UPDATE] libwebrtc を 127.6533.1.1 に上げる
   - @miosakuma
   - @zztkm
+- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
+  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
+    - `com.android.tools.build:gradle` を 8.5.0 に上げる
+    - ビルドに利用される Gradle を 8.7 に上げる
+    - Android マニフェストからビルドファイルにパッケージを移動する
+  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
+    - compileOptions を buildTypes から android ブロックに移動する
+      - Android 公式ドキュメントを参考にした修正
+      - https://developer.android.com/build/jdks?hl=ja#source-compat
+    - classifier を archiveClassifier に置き換える
+      - classifier は Gradle 8.0 で削除された
+      - https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
+    - compileSdkVersion と targetSdkVersion を 34 に上げる
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,10 @@
   - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
     - `com.android.tools.build:gradle` を 8.5.0 に上げる
     - ビルドに利用される Gradle を 8.7 に上げる
-    - Android マニフェストからビルドファイルにパッケージを移動する
+    - Android マニフェストからビルドファイルにパッケージを移動
+      - Android マニフェストに定義されていた package を削除
+      - ビルドファイルに namespace を追加
+    - buildTypes に定義されていた debug ブロックを削除
   - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
     - compileOptions を buildTypes から android ブロックに移動する
       - Android 公式ドキュメントを参考にした修正
@@ -27,6 +30,7 @@
       - classifier は Gradle 8.0 で削除された
       - https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
     - compileSdkVersion と targetSdkVersion を 34 に上げる
+    - AGP 8.0 から buildConfig がデフォルト false になったので、true に設定する
   - GitHub Actions で利用する JDK のバージョンを 17 にする
   - JitPack でのビルドで利用する JDK のバージョンを 17 にする
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
     - compileSdkVersion と targetSdkVersion を 34 に上げる
   - GitHub Actions で利用する JDK のバージョンを 17 にする
   - JitPack でのビルドで利用する JDK のバージョンを 17 にする
+  - @zztkm
 - [UPDATE] GitHub Actions の起動イベントに workflow_dispatch を追加
   - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath 'org.ajoberstar.grgit:grgit-gradle:5.2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -24,21 +24,19 @@ android {
             java.srcDirs += 'src/test/kotlin'
         }
     }
-    buildTypes {
-        debug {
-            debuggable true
-        }
-        release {
-        }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    buildTypes {
+        release {
+        }
     }
 
     testOptions {
         unitTests.includeAndroidResources = true
     }
+    namespace 'jp.shiguredo.sora.sdk'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -29,6 +29,8 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildTypes {
+        // Android Studio でのデバッグビルドタイプはデフォルトで debuggable true としてビルドされるため
+        // AGP Upgrade Assistant によって debug ブロックは削除された。
         release {
         }
     }

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'org.jlleitschuh.gradle.ktlint'
 group = 'com.github.shiguredo'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 34
 
         buildConfigField("String", "REVISION", "\"${grgit.head().abbreviatedId}\"")
         buildConfigField("String", "LIBWEBRTC_VERSION", "\"${libwebrtc_version}\"")

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -30,10 +30,10 @@ android {
         }
         release {
         }
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     }
 
     testOptions {
@@ -110,7 +110,9 @@ configurations.all {
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    // classifier は archiveClassifier に置き換えられました
+    // https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -119,7 +119,7 @@ configurations.all {
 }
 
 task sourcesJar(type: Jar) {
-    // classifier は archiveClassifier に置き換えられました
+    // classifier は archiveClassifier に置き換えられた
     // https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
     archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -29,6 +29,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildFeatures {
+        // AGP 8.0 からデフォルトで false になった
+        // このオプションが true でないと、defaultConfig に含まれている
+        // buidlConfigField オプションが無効になってしまうため、true に設定する
+        // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes
         buildConfig true
     }
     buildTypes {
@@ -41,6 +45,8 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+    // AGP 8.0 からモジュールレベルの build script 内に namespace が必要になった
+    // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
     namespace 'jp.shiguredo.sora.sdk'
 }
 

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -28,6 +28,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    buildFeatures {
+        buildConfig true
+    }
     buildTypes {
         // Android Studio でのデバッグビルドタイプはデフォルトで debuggable true としてビルドされるため
         // AGP Upgrade Assistant によって debug ブロックは削除された。

--- a/sora-android-sdk/src/main/AndroidManifest.xml
+++ b/sora-android-sdk/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="jp.shiguredo.sora.sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
変更内容

- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
    - `com.android.tools.build:gradle` を 8.5.0 に上げる
    - ビルドに利用される Gradle を 8.7 に上げる
    - Android マニフェストからビルドファイルにパッケージを移動する
  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
    - compileOptions を buildTypes から android ブロックに移動する
      - Android 公式ドキュメントを参考にした修正
      - https://developer.android.com/build/jdks?hl=ja#source-compat
    - classifier を archiveClassifier に置き換える
      - classifier は Gradle 8.0 で削除された
      - https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier
    - compileSdkVersion と targetSdkVersion を 34 に上げる
  - GitHub Actions で利用する JDK のバージョンを 17 にする
  - JitPack でのビルドで利用する JDK のバージョンを 17 にする

---

This pull request includes several updates to the build configuration and dependencies for the Android project. The main changes involve upgrading the Android Gradle Plugin, updating the Gradle version, and modifying build scripts to accommodate these upgrades.

### Build Configuration Updates:

* **Java Version Update**: Changed the Java version from 18 to 17 in the GitHub Actions workflow to align with the default JDK version of Android Gradle Plugin 8.5 and its long-term support. (`.github/workflows/build.yml`)

* **Gradle Version Update**: Updated the Gradle distribution URL from version 7.6.1 to 8.7 in the `gradle-wrapper.properties` file. (`gradle/wrapper/gradle-wrapper.properties`)

* **JDK Version for JitPack**: Updated the JDK version from OpenJDK 11 to OpenJDK 17 in the `jitpack.yml` file. (`jitpack.yml`)

### Android Project Configuration:

* **Android SDK Versions Update**: Updated `compileSdkVersion` and `targetSdkVersion` from 32 to 34 in the `build.gradle` file. (`sora-android-sdk/build.gradle`)

* **Build Script Adjustments**:
  * Moved `compileOptions` from `buildTypes` to the `android` block.
  * Replaced `classifier` with `archiveClassifier` in the `sourcesJar` task.
  * Added `namespace` to the `android` block as required by AGP 8.0. (`sora-android-sdk/build.gradle`) [[1]](diffhunk://#diff-a8c74bab097992682aeb36631bc7d13d0de059d3868e4005e8bed4c5e0b6345cL27-R50) [[2]](diffhunk://#diff-a8c74bab097992682aeb36631bc7d13d0de059d3868e4005e8bed4c5e0b6345cL113-R124)
  * Removed the `package` attribute from the Android manifest file. (`sora-android-sdk/src/main/AndroidManifest.xml`)

### Documentation:

* **Changelog Update**: Added a detailed entry in `CHANGES.md` documenting the upgrade to Android Gradle Plugin 8.5.0, including changes to Gradle, build script adjustments, and JDK version updates for GitHub Actions and JitPack. (`CHANGES.md`)

