### PR TITLE
依存ライブラリをバージョンアップする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
   - org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.8.1 に上げる
   - androidx.test:core を 1.6.1 に上げる
   - org.robolectric:robolectric を 4.13 に上げる
+  - @zztkm
 - [FIX] Offer メッセージの encodings 内 maxFramerate の値が整数でない値であった場合にエラーとなる問題を修正
   - W3C では maxFramerate を Double で定義しているが、libwebrtc では Integer となっているため、SDK も Integer を使用していた
   - W3C の定義に合わせて Double を受け入れるようにし、また SDK 内部では libwebrtc に合わせて Integer とする方針となった

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
   - androidx.test:core を 1.6.1 に上げる
   - org.robolectric:robolectric を 4.13 に上げる
   - @zztkm
+- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
+  - @zztkm
 - [FIX] Offer メッセージの encodings 内 maxFramerate の値が整数でない値であった場合にエラーとなる問題を修正
   - W3C では maxFramerate を Double で定義しているが、libwebrtc では Integer となっているため、SDK も Integer を使用していた
   - W3C の定義に合わせて Double を受け入れるようにし、また SDK 内部では libwebrtc に合わせて Integer とする方針となった

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,12 @@
 - [UPDATE] GitHub Actions の定期実行をやめる
   - build.yml の起動イベントから schedule を削除
   - @zztkm
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.google.code.gson:gson を 2.11.0 に上げる
+  - com.squareup.okhttp3:okhttp を 4.12.0 に上げる
+  - org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.8.1 に上げる
+  - androidx.test:core を 1.6.1 に上げる
+  - org.robolectric:robolectric を 4.13 に上げる
 - [FIX] Offer メッセージの encodings 内 maxFramerate の値が整数でない値であった場合にエラーとなる問題を修正
   - W3C では maxFramerate を Double で定義しているが、libwebrtc では Integer となっているため、SDK も Integer を使用していた
   - W3C の定義に合わせて Double を受け入れるようにし、また SDK 内部では libwebrtc に合わせて Integer とする方針となった

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.9.25'
     ext.libwebrtc_version = '127.6533.1.1'
 
     ext.dokka_version = '1.8.10'

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -94,9 +94,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
     // required by "signaling" part
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
 
     // required by "rtc" part
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
@@ -104,8 +104,8 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test:core:1.5.0'
-    testImplementation('org.robolectric:robolectric:4.9.2') {
+    testImplementation 'androidx.test:core:1.6.1'
+    testImplementation('org.robolectric:robolectric:4.13') {
         exclude group: 'com.google.auto.service', module: 'auto-service'
     }
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"


### PR DESCRIPTION
変更内容

- [UPDATE] 依存ライブラリーのバージョンを上げる
  - com.google.code.gson:gson を 2.11.0 に上げる
  - com.squareup.okhttp3:okhttp を 4.12.0 に上げる
  - org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.8.1 に上げる
  - androidx.test:core を 1.6.1 に上げる
  - org.robolectric:robolectric を 4.13 に上げる
- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる

---
This pull request includes updates to dependencies and Kotlin version in the `sora-android-sdk` project. The most important changes include updating various library versions and the Kotlin version.

Dependency updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R37-R45): Updated the versions of several dependencies, including `gson`, `okhttp`, `kotlinx-coroutines-android`, `androidx.test:core`, and `robolectric`.
* [`sora-android-sdk/build.gradle`](diffhunk://#diff-a8c74bab097992682aeb36631bc7d13d0de059d3868e4005e8bed4c5e0b6345cL97-R108): Updated the versions of `gson` to 2.11.0, `okhttp` to 4.12.0, `kotlinx-coroutines-android` to 1.8.1, `androidx.test:core` to 1.6.1, and `robolectric` to 4.13.

Kotlin version update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R37-R45): Updated the Kotlin version to 1.9.25.