### PR TITLE
JitPack での Gradle Task の暗黙的な依存関係によるビルドエラーを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [FIX] Gradle Task の暗黙的な依存関係によるビルドエラーを修正する
+- [FIX] JitPack で発生した Gradle Task の暗黙的な依存関係によるビルドエラーを修正する
   - `generateMetadataFileForSora-android-sdkPublication` は暗黙的に `sourcesJar` に依存していた
   - このため、タスクの実行順序によってはビルドエラーが発生する状況になっており、kotlin 1.9 に上げたタイミングで問題が発現した
   - この問題に対処するために、`generateMetadataFileForSora-android-sdkPublication` が `sourcesJar` に依存していることを明示的に宣言した

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [FIX] Gradle Task の暗黙的な依存関係によるビルドエラーを修正する
+  - `generateMetadataFileForSora-android-sdkPublication` は暗黙的に `sourcesJar` に依存していた
+  - このため、タスクの実行順序によってはビルドエラーが発生する状況になっており、kotlin 1.9 に上げたタイミングで問題が発現した
+  - この問題に対処するために、`generateMetadataFileForSora-android-sdkPublication` が `sourcesJar` に依存していることを明示的に宣言した
+  - @zztkm
+
 ## 2024.3.0
 
 **リリース日**: 2024-08-29

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.9.25'
     ext.libwebrtc_version = '127.6533.1.1'
 
     ext.dokka_version = '1.8.10'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '1.8.10'
     ext.libwebrtc_version = '127.6533.1.1'
 
     ext.dokka_version = '1.8.10'

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -126,7 +126,6 @@ task sourcesJar(type: Jar) {
 }
 
 tasks.whenTaskAdded { task ->
-    println("task.name = ${task.name}")
     if (task.name == "generateMetadataFileForSora-android-sdkPublication") {
         task.dependsOn("sourcesJar")
     }

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -126,6 +126,10 @@ task sourcesJar(type: Jar) {
 }
 
 tasks.whenTaskAdded { task ->
+    // kotlin 1.9 に上げたタイミングで、generateMetadataFileForSora-android-sdkPublication が
+    // sourcesJar より先に実行されるようになってしまい JitPack でビルドエラーが発生した。
+    // 、generateMetadataFileForSora-android-sdkPublication は sourcesJar の出力を使用するためである。
+    // この問題に対処するために、generateMetadataFileForSora-android-sdkPublication が sourcesJar に依存していることを明示的に宣言する。
     if (task.name == "generateMetadataFileForSora-android-sdkPublication") {
         task.dependsOn("sourcesJar")
     }

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -129,6 +129,7 @@ task sourcesJar(type: Jar) {
 // generateMetadataFileForSora-android-sdkPublication が存在する場合は、sourcesJar 生成後に実行する
 def publicationTask = tasks.findByName("generateMetadataFileForSora-android-sdkPublication")
 if (publicationTask != null) {
+    println("publicationTask depends on sourcesJar")
     publicationTask.dependsOn(tasks.named("sourcesJar"))
 }
 

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -126,8 +126,8 @@ task sourcesJar(type: Jar) {
 }
 
 tasks.whenTaskAdded { task ->
-    // kotlin 1.9 に上げたタイミングで、generateMetadataFileForSora-android-sdkPublication が
-    // sourcesJar より先に実行されるようになってしまい JitPack でビルドエラーが発生した。
+    // kotlin 1.9 に上げたタイミングで、JitPack で generateMetadataFileForSora-android-sdkPublication が
+    // sourcesJar より先に実行されるようになってしまい ビルドエラーが発生した。
     // 、generateMetadataFileForSora-android-sdkPublication は sourcesJar の出力を使用するためである。
     // この問題に対処するために、generateMetadataFileForSora-android-sdkPublication が sourcesJar に依存していることを明示的に宣言する。
     if (task.name == "generateMetadataFileForSora-android-sdkPublication") {

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -125,6 +125,13 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
+
+// generateMetadataFileForSora-android-sdkPublication が存在する場合は、sourcesJar 生成後に実行する
+def publicationTask = tasks.findByName("generateMetadataFileForSora-android-sdkPublication")
+if (publicationTask != null) {
+    publicationTask.dependsOn(tasks.named("sourcesJar"))
+}
+
 artifacts {
     archives sourcesJar
 }

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -125,12 +125,11 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-
-// generateMetadataFileForSora-android-sdkPublication が存在する場合は、sourcesJar 生成後に実行する
-def publicationTask = tasks.findByName("generateMetadataFileForSora-android-sdkPublication")
-if (publicationTask != null) {
-    println("publicationTask depends on sourcesJar")
-    publicationTask.dependsOn(tasks.named("sourcesJar"))
+tasks.whenTaskAdded { task ->
+    println("task.name = ${task.name}")
+    if (task.name == "generateMetadataFileForSora-android-sdkPublication") {
+        task.dependsOn("sourcesJar")
+    }
 }
 
 artifacts {


### PR DESCRIPTION
- [FIX] Gradle Task の暗黙的な依存関係によるビルドエラーを修正する
  - `generateMetadataFileForSora-android-sdkPublication` は暗黙的に `sourcesJar` に依存していた
  - このため、タスクの実行順序によってはビルドエラーが発生する状況になっており、kotlin 1.9 に上げたタイミングで問題が発現した
  - この問題に対処するために、`generateMetadataFileForSora-android-sdkPublication` が `sourcesJar` に依存していることを明示的に宣言した


JitPack のビルド結果:
https://jitpack.io/com/github/shiguredo/sora-android-sdk/feature~test-jitpack-build-2021.1-gd9c3776-542/build.log

---

This pull request addresses a build error caused by implicit dependencies between Gradle tasks in the `sora-android-sdk` project. The key change is the explicit declaration of a dependency to ensure proper task execution order.

### Fixes for build errors:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R19): Documented the fix for the build error caused by the implicit dependency of the `generateMetadataFileForSora-android-sdkPublication` task on `sourcesJar`. This error surfaced when upgrading to Kotlin 1.9.
* [`sora-android-sdk/build.gradle`](diffhunk://#diff-a8c74bab097992682aeb36631bc7d13d0de059d3868e4005e8bed4c5e0b6345cR128-R137): Added a task dependency to explicitly declare that `generateMetadataFileForSora-android-sdkPublication` depends on `sourcesJar`, preventing build errors on JitPack.
