### PR TITLE
libwebrtc を 129.6668.1.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] libwebrtc を 129.6668.1.0 に上げる
+  - @miosakuma
 - [FIX] SoraMediaChannel のコンストラクタで `signalingMetadata` と `signalingNotifyMetadata` に Map オブジェクトを指定した場合、null を持つフィールドが connect メッセージ送信時に省略されてしまう問題を修正
   - `signalingMetadata` と `signalingNotifyMetadata` に設定する情報はユーザが任意に設定する項目であり value 値が null の情報も送信できるようにする必要がある
   - Gson は JSON シリアライズ時、デフォルトで null フィールドを無視するので、null を持つフィールドは省略される

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sora Android SDK
 
 [![Release](https://jitpack.io/v/shiguredo/sora-android-sdk.svg)](https://jitpack.io/#shiguredo/sora-android-sdk)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-127.6533-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6533)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-129.6668-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6668)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/shiguredo/sora-android-sdk.svg)](https://github.com/shiguredo/sora-android-sdk.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.libwebrtc_version = '127.6533.1.1'
+    ext.libwebrtc_version = '129.6668.1.0'
 
     ext.dokka_version = '1.8.10'
 


### PR DESCRIPTION
- [UPDATE] libwebrtc を 129.6668.1.0 に上げる

サンプルアプリがビルドされることを確認済です

---
This pull request includes updates to the `libwebrtc` version and a fix for metadata handling in the `SoraMediaChannel` constructor. The most important changes are listed below:

### Version Update:
* Updated `libwebrtc` to version `129.6668.1.0` in the `CHANGES.md` file.
* Updated the `libwebrtc` badge in the `README.md` file to reflect the new version `129.6668`.

### Bug Fix:
* Fixed an issue in the `SoraMediaChannel` constructor where `signalingMetadata` and `signalingNotifyMetadata` fields with `null` values were being omitted in the connect message.