### PR TITLE
マルチストリーム関連設定を非推奨にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする
+  - @zztkm
+- [UPDATE] `SoraMediaOption` に `enableLegacyStream` を追加する
+  - レガシーストリームのための関数だが、レガシーストリームは廃止予定なので最初から非推奨にしている
+  - @zztkm
+
 ## 2025.1.0
 
 **リリース日**: 2025-01-27

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -502,7 +502,7 @@ class SoraMediaChannel @JvmOverloads constructor(
 
         override fun onAddRemoteStream(ms: MediaStream) {
             SoraLogger.d(TAG, "[channel:$role] @peer:onAddRemoteStream msid=:${ms.id}, connectionId=$connectionId")
-            if (mediaOption.multistreamEnabled && connectionId != null && ms.id == connectionId) {
+            if (mediaOption.multistreamEnabled == true && connectionId != null && ms.id == connectionId) {
                 SoraLogger.d(TAG, "[channel:$role] this stream is mine, ignore: ${ms.id}")
                 return
             }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -19,7 +19,7 @@ class SoraMediaOption {
     internal var audioUpstreamEnabled = false
     internal var videoDownstreamEnabled = false
     internal var videoUpstreamEnabled = false
-    internal var multistreamEnabled = false
+    internal var multistreamEnabled: Boolean? = null
     internal var spotlightOption: SoraSpotlightOption? = null
     internal var simulcastEnabled = false
     internal var simulcastRid: SoraVideoOption.SimulcastRid? = null
@@ -172,8 +172,21 @@ class SoraMediaOption {
      * - Sora ドキュメントのマルチストリーム
      *   [](https://sora.shiguredo.jp/doc/MULTISTREAM.html)
      */
+    @Deprecated(
+        message = "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。",
+    )
     fun enableMultistream() {
         multistreamEnabled = true
+    }
+
+    /**
+     * レガシーストリームを有効にします.
+     */
+    @Deprecated(
+        message = "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。",
+    )
+    fun enableLegacyStream() {
+        multistreamEnabled = false
     }
 
     /**
@@ -209,7 +222,8 @@ class SoraMediaOption {
                 // 双方向通信の場合は multistream フラグを立てる
                 true
             else ->
-                multistreamEnabled
+                // 未設定の場合は true として扱う
+                multistreamEnabled ?: true
         }
         set(value) {
             _multistreamIsRequired = value

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -28,7 +28,7 @@ data class ConnectMessage(
     @SerializedName("metadata") val metadata: Any? = null,
     @SerializedName("signaling_notify_metadata")
     val signalingNotifyMetadata: Any? = null,
-    @SerializedName("multistream") val multistream: Boolean = false,
+    @SerializedName("multistream") val multistream: Boolean? = null,
     @SerializedName("spotlight") var spotlight: Any? = null,
     @SerializedName("spotlight_number")
     var spotlightNumber: Int? = null,


### PR DESCRIPTION
- [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする
- [UPDATE] `SoraMediaOption` に `enableLegacyStream` を追加する
  - レガシーストリームのための関数だが、レガシーストリームは廃止予定なので最初から非推奨にしている

---

This pull request introduces several updates and deprecations to the `SoraMediaOption` class, particularly around the handling of multistream and legacy stream functionalities. Additionally, there are some minor changes to the `SoraMediaChannel` class to improve code clarity.

### Updates and Deprecations in `SoraMediaOption`:

* Deprecated the `enableMultistream` method, indicating that the multistream feature will be removed in the June 2025 release of Sora.
* Added a new method `enableLegacyStream`, which is also deprecated from the start, as the legacy stream feature is planned for removal in June 2025.
* Changed the `multistreamEnabled` property from a Boolean to a nullable Boolean to allow for an unset state, and updated its usage to treat an unset state as `true`. [[1]](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427L22-R22) [[2]](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427L212-R226)

### Code Clarity Improvements in `SoraMediaChannel`:

* Updated the condition in the `onAddRemoteStream` method to explicitly check if `multistreamEnabled` is `true` for better readability.

### Documentation:

* Updated `CHANGES.md` to reflect the deprecations and additions in `SoraMediaOption`.