### PR TITLE
リスト形式の転送フィルターに対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,16 +13,16 @@
 
 - [UPDATE] libwebrtc を 129.6668.1.0 に上げる
   - @miosakuma
-- [UPDATE] 転送フィルター機能の設定を 2025 年 12 月の廃止に向けて非推奨にする
-  - 転送フィルター機能の設定が非推奨になるクラス
+- [UPDATE] 単一の転送フィルターを設定するためのプロパティを 2025 年 12 月の廃止に向けて非推奨にする
+  - 単一の転送フィルター設定プロパティが非推奨になるクラス
     - SoraMediaChannel
     - SignalingChannelImpl
     - ConnectMessage
   - @zztkm
 - [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
   - @zztkm
-- [ADD] マルチ転送フィルター機能の設定用プロパティを追加する
-  - マルチ転送フィルター機能の設定用プロパティが追加されるクラス
+- [ADD] 転送フィルターをリスト形式で指定するためのプロパティを追加する
+  - プロパティが追加されるクラス
     - SoraMediaChannel に `forwardingFiltersOption` を追加する
     - SignalingChannelImpl に `forwardingFiltersOption` を追加する
     - ConnectMessage に `forwardingFilters` を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,21 @@
 
 - [UPDATE] libwebrtc を 129.6668.1.0 に上げる
   - @miosakuma
+- [UPDATE] 転送フィルター機能の設定を 2025 年 12 月の廃止に向けて非推奨にする
+  - 転送フィルター機能の設定が非推奨になるクラス
+    - SoraMediaChannel
+    - SignalingChannelImpl
+    - ConnectMessage
+  - @zztkm
+- [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
+  - @zztkm
+- [ADD] マルチ転送フィルター機能の設定用プロパティを追加する
+  - マルチ転送フィルター機能の設定用プロパティが追加されるクラス
+    - SoraMediaChannel に `forwardingFiltersOption` を追加する
+    - SignalingChannelImpl に `forwardingFiltersOption` を追加する
+    - ConnectMessage に `forwardingFilters` を追加する
+    - クラスそのものに変更はないが `MessageConverter.buildConnectMessage` に `forwardingFiltersOption` を追加する
+  - @zztkm
 - [FIX] SoraMediaChannel のコンストラクタで `signalingMetadata` と `signalingNotifyMetadata` に Map オブジェクトを指定した場合、null を持つフィールドが connect メッセージ送信時に省略されてしまう問題を修正
   - `signalingMetadata` と `signalingNotifyMetadata` に設定する情報はユーザが任意に設定する項目であり value 値が null の情報も送信できるようにする必要がある
   - Gson は JSON シリアライズ時、デフォルトで null フィールドを無視するので、null を持つフィールドは省略される

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,12 @@
 
 - [UPDATE] libwebrtc を 129.6668.1.0 に上げる
   - @miosakuma
-- [UPDATE] 単一の転送フィルターを設定するためのプロパティを 2025 年 12 月の廃止に向けて非推奨にする
-  - 単一の転送フィルター設定プロパティが非推奨になるクラス
+- [UPDATE] SoraForwardingFilterOption 型の引数を 2025 年 12 月の廃止に向けて非推奨にする
+  - 今後はリスト形式の転送フィルター設定を利用してもらう
+  - 非推奨になるクラス
     - SoraMediaChannel
     - SignalingChannelImpl
-    - ConnectMessage
+    - ConnectMessage (Any で定義されていますが、実態は SoraForwardingFilterOption)
   - @zztkm
 - [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [UPDATE] libwebrtc を 129.6668.1.0 に上げる
   - @miosakuma
-- [UPDATE] SoraForwardingFilterOption 型の引数を 2025 年 12 月の廃止に向けて非推奨にする
+- [UPDATE] SoraForwardingFilterOption 型の引数を Sora での 2025 年 12 月の廃止に向けて非推奨にする
   - 今後はリスト形式の転送フィルター設定を利用してもらう
   - 非推奨になるクラス
     - SoraMediaChannel

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
   - 非推奨になるクラス
     - SoraMediaChannel
     - SignalingChannelImpl
-    - ConnectMessage (Any で定義されていますが、実態は SoraForwardingFilterOption)
+    - ConnectMessage (Any で定義されているが、実態は SoraForwardingFilterOption を Map に変換したもの)
   - @zztkm
 - [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -87,6 +87,11 @@ class SoraMediaChannel @JvmOverloads constructor(
     ignoreDisconnectWebSocket: Boolean? = null,
     dataChannels: List<Map<String, Any>>? = null,
     private var bundleId: String? = null,
+    @Deprecated(
+        "2025 年 12 月に廃止します。",
+        ReplaceWith("forwardingFiltersOption"),
+        DeprecationLevel.WARNING
+    )
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
     private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
 ) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -69,6 +69,7 @@ import kotlin.concurrent.schedule
  * @param dataChannels connect メッセージに含める `data_channels`
  * @param bundleId connect メッセージに含める `bundle_id`
  * @param forwardingFilterOption 転送フィルター機能の設定
+ * @param forwardingFiltersOption マルチ転送フィルター機能の設定
  */
 class SoraMediaChannel @JvmOverloads constructor(
     private val context: Context,
@@ -87,6 +88,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     dataChannels: List<Map<String, Any>>? = null,
     private var bundleId: String? = null,
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
+    private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
 ) {
     companion object {
         private val TAG = SoraMediaChannel::class.simpleName
@@ -672,6 +674,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             |bundleId                   = ${this.bundleId}
             |signalingNotifyMetadata    = ${this.signalingNotifyMetadata}
             |forwardingFilter           = ${this.forwardingFilterOption}
+            |forwardingFilters           = ${this.forwardingFiltersOption}
             """.trimMargin()
         )
 
@@ -781,7 +784,8 @@ class SoraMediaChannel @JvmOverloads constructor(
             signalingNotifyMetadata = signalingNotifyMetadata,
             connectDataChannels = connectDataChannels,
             redirect = redirectLocation != null,
-            forwardingFilterOption = forwardingFilterOption
+            forwardingFilterOption = forwardingFilterOption,
+            forwardingFiltersOption = forwardingFiltersOption
         )
         signaling!!.connect()
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -88,7 +88,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     dataChannels: List<Map<String, Any>>? = null,
     private var bundleId: String? = null,
     @Deprecated(
-        "2025 年 12 月に廃止します。",
+        "この項目は 2025 年 12 月リリース予定の Sora にて廃止されます",
         ReplaceWith("forwardingFiltersOption"),
         DeprecationLevel.WARNING
     )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -69,7 +69,7 @@ import kotlin.concurrent.schedule
  * @param dataChannels connect メッセージに含める `data_channels`
  * @param bundleId connect メッセージに含める `bundle_id`
  * @param forwardingFilterOption 転送フィルター機能の設定
- * @param forwardingFiltersOption マルチ転送フィルター機能の設定
+ * @param forwardingFiltersOption リスト形式の転送フィルター機能の設定
  */
 class SoraMediaChannel @JvmOverloads constructor(
     private val context: Context,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraForwardingFilterOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraForwardingFilterOption.kt
@@ -9,6 +9,8 @@ package jp.shiguredo.sora.sdk.channel.option
  * @param metadata 転送フィルターのメタデータ
  */
 class SoraForwardingFilterOption(
+    var name: String? = null,
+    var priority: Int? = null,
     val action: Action? = null,
     val rules: List<List<Rule>>,
     val version: String? = null,
@@ -66,6 +68,8 @@ class SoraForwardingFilterOption(
     internal val signaling: Any
         get() {
             return mapOf(
+                "name" to name,
+                "priority" to priority,
                 "action" to (action?.name?.lowercase() ?: null),
                 "rules" to rules.map { outerRule ->
                     outerRule.map { rule ->

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraForwardingFilterOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraForwardingFilterOption.kt
@@ -3,6 +3,8 @@ package jp.shiguredo.sora.sdk.channel.option
 /**
  * 転送フィルター機能の設定を表すクラスです。
  *
+ * @param name 転送フィルターの名前
+ * @param priority 転送フィルターの優先度
  * @param action 転送フィルター適用時の挙動
  * @param rules 転送フィルターの適用ルール
  * @param version 転送フィルターのバージョン

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -68,6 +68,11 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val signalingNotifyMetadata: Any? = null,
     private val connectDataChannels: List<Map<String, Any>>? = null,
     private val redirect: Boolean = false,
+    @Deprecated(
+        "2025 年 12 月に廃止します。",
+        ReplaceWith("forwardingFiltersOption"),
+        DeprecationLevel.WARNING
+    )
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
     private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
 ) : SignalingChannel {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -69,6 +69,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val connectDataChannels: List<Map<String, Any>>? = null,
     private val redirect: Boolean = false,
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
+    private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
 ) : SignalingChannel {
 
     companion object {
@@ -260,7 +261,8 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 signalingNotifyMetadata = signalingNotifyMetadata,
                 dataChannels = connectDataChannels,
                 redirect = redirect,
-                forwardingFilterOption = forwardingFilterOption
+                forwardingFilterOption = forwardingFilterOption,
+                forwardingFiltersOption = forwardingFiltersOption
             )
             it.send(message)
         }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -69,7 +69,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val connectDataChannels: List<Map<String, Any>>? = null,
     private val redirect: Boolean = false,
     @Deprecated(
-        "2025 年 12 月に廃止します。",
+        "この項目は 2025 年 12 月リリース予定の Sora にて廃止されます",
         ReplaceWith("forwardingFiltersOption"),
         DeprecationLevel.WARNING
     )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -51,7 +51,7 @@ data class ConnectMessage(
     @SerializedName("redirect") var redirect: Boolean? = null,
     @Deprecated(
         "2025 年 12 月に廃止します。",
-        ReplaceWith("forwardingFiltersOption"),
+        ReplaceWith("forwardingFilters"),
         DeprecationLevel.WARNING
     )
     @SerializedName("forwarding_filter") val forwardingFilter: Any? = null,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -49,6 +49,11 @@ data class ConnectMessage(
     @SerializedName("audio_streaming_language_code")
     val audioStreamingLanguageCode: String? = null,
     @SerializedName("redirect") var redirect: Boolean? = null,
+    @Deprecated(
+        "2025 年 12 月に廃止します。",
+        ReplaceWith("forwardingFiltersOption"),
+        DeprecationLevel.WARNING
+    )
     @SerializedName("forwarding_filter") val forwardingFilter: Any? = null,
     @SerializedName("forwarding_filters") val forwardingFilters: List<Any>? = null
 )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -49,7 +49,8 @@ data class ConnectMessage(
     @SerializedName("audio_streaming_language_code")
     val audioStreamingLanguageCode: String? = null,
     @SerializedName("redirect") var redirect: Boolean? = null,
-    @SerializedName("forwarding_filter") val forwardingFilter: Any? = null
+    @SerializedName("forwarding_filter") val forwardingFilter: Any? = null,
+    @SerializedName("forwarding_filters") val forwardingFilters: List<Any>? = null
 )
 
 data class VideoSetting(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -50,7 +50,7 @@ data class ConnectMessage(
     val audioStreamingLanguageCode: String? = null,
     @SerializedName("redirect") var redirect: Boolean? = null,
     @Deprecated(
-        "2025 年 12 月に廃止します。",
+        "この項目は 2025 年 12 月リリース予定の Sora にて廃止されます",
         ReplaceWith("forwardingFilters"),
         DeprecationLevel.WARNING
     )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -44,6 +44,7 @@ class MessageConverter {
             dataChannels: List<Map<String, Any>>? = null,
             redirect: Boolean = false,
             forwardingFilterOption: SoraForwardingFilterOption? = null,
+            forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
         ): String {
 
             val msg = ConnectMessage(
@@ -60,6 +61,7 @@ class MessageConverter {
                 signalingNotifyMetadata = signalingNotifyMetadata,
                 audioStreamingLanguageCode = mediaOption.audioStreamingLanguageCode,
                 forwardingFilter = forwardingFilterOption?.signaling,
+                forwardingFilters = forwardingFiltersOption?.map { it.signaling }
             )
 
             if (mediaOption.upstreamIsRequired) {


### PR DESCRIPTION
- [UPDATE] SoraForwardingFilterOption 型の引数を 2025 年 12 月の廃止に向けて非推奨にする
  - 今後はリスト形式の転送フィルター設定を利用してもらう
  - 非推奨になるクラス
    - SoraMediaChannel
    - SignalingChannelImpl
    - ConnectMessage (Any で定義されているが、実態は SoraForwardingFilterOption を Map に変換したもの)
  - @zztkm
- [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
  - @zztkm
- [ADD] 転送フィルターをリスト形式で指定するためのプロパティを追加する
  - プロパティが追加されるクラス
    - SoraMediaChannel に `forwardingFiltersOption` を追加する
    - SignalingChannelImpl に `forwardingFiltersOption` を追加する
    - ConnectMessage に `forwardingFilters` を追加する
    - クラスそのものに変更はないが `MessageConverter.buildConnectMessage` に `forwardingFiltersOption` を追加する
  - @zztkm

---

This pull request introduces several changes to the `sora-android-sdk` to deprecate the `SoraForwardingFilterOption` type argument and replace it with a list-based forwarding filter configuration. Additionally, new properties have been added to the `SoraForwardingFilterOption` class.

Deprecation and new properties:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R90-R96): Deprecated the `forwardingFilterOption` parameter and added a new `forwardingFiltersOption` parameter to support list-based forwarding filter configuration. [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R90-R96) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R682) [[3]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L784-R793)
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraForwardingFilterOption.kt`](diffhunk://#diff-368d52e85f5df983cc7f3ff512ba3398cd89b849a0def914f93365c8943572ffR6-R15): Added `name` and `priority` properties to the `SoraForwardingFilterOption` class. [[1]](diffhunk://#diff-368d52e85f5df983cc7f3ff512ba3398cd89b849a0def914f93365c8943572ffR6-R15) [[2]](diffhunk://#diff-368d52e85f5df983cc7f3ff512ba3398cd89b849a0def914f93365c8943572ffR73-R74)

Updates to related classes:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt`](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R71-R77): Deprecated the `forwardingFilterOption` parameter and added a new `forwardingFiltersOption` parameter in the `SignalingChannelImpl` class. [[1]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R71-R77) [[2]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8L263-R270)
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880L52-R58): Deprecated the `forwardingFilter` property and added a new `forwardingFilters` property in the `ConnectMessage` data class.
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt`](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR47): Updated the `MessageConverter.buildConnectMessage` method to include the new `forwardingFiltersOption` parameter. [[1]](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR47) [[2]](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR64)

Documentation:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R31): Documented the deprecation of `SoraForwardingFilterOption` and the addition of new properties and list-based configuration for forwarding filters.