### PR TITLE
libwebrtc を m131.6778.4.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,7 @@
 ## develop
 
 - [UPDATE] libwebrtc を 131.6778.4.0 に上げる
-  - @miosakuma
-  - @zztkm
+  - @miosakuma @zztkm
 - [UPDATE] SoraForwardingFilterOption 型の引数を Sora での 2025 年 12 月の廃止に向けて非推奨にする
   - 今後はリスト形式の転送フィルター設定を利用してもらう
   - 非推奨になるクラス

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@
 
 ## develop
 
-- [UPDATE] libwebrtc を 129.6668.1.0 に上げる
+- [UPDATE] libwebrtc を 131.6778.4.0 に上げる
   - @miosakuma
+  - @zztkm
 - [UPDATE] SoraForwardingFilterOption 型の引数を Sora での 2025 年 12 月の廃止に向けて非推奨にする
   - 今後はリスト形式の転送フィルター設定を利用してもらう
   - 非推奨になるクラス

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sora Android SDK
 
 [![Release](https://jitpack.io/v/shiguredo/sora-android-sdk.svg)](https://jitpack.io/#shiguredo/sora-android-sdk)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-129.6668-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6668)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-131.6778-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6778)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/shiguredo/sora-android-sdk.svg)](https://github.com/shiguredo/sora-android-sdk.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.libwebrtc_version = '129.6668.1.0'
+    ext.libwebrtc_version = '131.6778.4.0'
 
     ext.dokka_version = '1.8.10'
 


### PR DESCRIPTION
- [UPDATE] libwebrtc を 131.6778.4.0 に上げる

---

This pull request includes updates to the `libwebrtc` version in the `CHANGES.md` and `README.md` files.

Version updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R15): Updated `libwebrtc` version from `129.6668.1.0` to `131.6778.4.0` and added an additional contributor.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated `libwebrtc` badge version from `129.6668` to `131.6778`.