### PR TITLE
scaleResolutionDownTo を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
     - ConnectMessage に `forwardingFilters` を追加する
     - クラスそのものに変更はないが `MessageConverter.buildConnectMessage` に `forwardingFiltersOption` を追加する
   - @zztkm
+- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
+  - @zztkm
 - [FIX] SoraMediaChannel のコンストラクタで `signalingMetadata` と `signalingNotifyMetadata` に Map オブジェクトを指定した場合、null を持つフィールドが connect メッセージ送信時に省略されてしまう問題を修正
   - `signalingMetadata` と `signalingNotifyMetadata` に設定する情報はユーザが任意に設定する項目であり value 値が null の情報も送信できるようにする必要がある
   - Gson は JSON シリアライズ時、デフォルトで null フィールドを無視するので、null を持つフィールドは省略される

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 - [UPDATE] `SoraMediaOption` に `enableLegacyStream` を追加する
   - レガシーストリームのための関数だが、レガシーストリームは廃止予定なので最初から非推奨にしている
   - @zztkm
+- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
+  - @zztkm
 
 ## 2025.1.0
 
@@ -67,8 +69,6 @@
     - SignalingChannelImpl に `forwardingFiltersOption` を追加する
     - ConnectMessage に `forwardingFilters` を追加する
     - クラスそのものに変更はないが `MessageConverter.buildConnectMessage` に `forwardingFiltersOption` を追加する
-  - @zztkm
-- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] SoraMediaChannel のコンストラクタで `signalingMetadata` と `signalingNotifyMetadata` に Map オブジェクトを指定した場合、null を持つフィールドが connect メッセージ送信時に省略されてしまう問題を修正
   - `signalingMetadata` と `signalingNotifyMetadata` に設定する情報はユーザが任意に設定する項目であり value 値が null の情報も送信できるようにする必要がある

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -394,6 +394,12 @@ class PeerChannelImpl(
         listener?.onSenderEncodings(parameters.encodings)
         parameters.encodings.forEach {
             with(it) {
+                val scaleResolutionDownTo = scaleResolutionDownTo
+                val scaleResolutionDownToMessage = if (scaleResolutionDownTo != null) {
+                    "(maxWidth: ${scaleResolutionDownTo.maxWidth}, maxHeight: ${scaleResolutionDownTo.maxHeight})"
+                } else {
+                    "null"
+                }
                 SoraLogger.d(
                     TAG,
                     "update sender encoding: " +
@@ -401,7 +407,7 @@ class PeerChannelImpl(
                         "rid=$rid, " +
                         "active=$active, " +
                         "scaleResolutionDownBy=$scaleResolutionDownBy, " +
-                        "scaleResolutionDownTo=$scaleResolutionDownTo, " +
+                        "scaleResolutionDownTo=$scaleResolutionDownToMessage, " +
                         "scalabilityMode=$scalabilityMode, " +
                         "maxFramerate=$maxFramerate, " +
                         "maxBitrateBps=$maxBitrateBps, " +

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -386,6 +386,7 @@ class PeerChannelImpl(
             offerEncoding.maxBitrate?.also { senderEncoding.maxBitrateBps = it }
             offerEncoding.maxFramerate?.also { senderEncoding.maxFramerate = it.toInt() }
             offerEncoding.scaleResolutionDownBy?.also { senderEncoding.scaleResolutionDownBy = it }
+            offerEncoding.scaleResolutionDownTo?.also { senderEncoding.scaleResolutionDownTo = it }
             offerEncoding.scalabilityMode?.also { senderEncoding.scalabilityMode = it }
         }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -401,6 +401,7 @@ class PeerChannelImpl(
                         "rid=$rid, " +
                         "active=$active, " +
                         "scaleResolutionDownBy=$scaleResolutionDownBy, " +
+                        "scaleResolutionDownTo=$scaleResolutionDownTo, " +
                         "scalabilityMode=$scalabilityMode, " +
                         "maxFramerate=$maxFramerate, " +
                         "maxBitrateBps=$maxBitrateBps, " +

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -2,6 +2,7 @@ package jp.shiguredo.sora.sdk.channel.signaling.message
 
 import com.google.gson.annotations.SerializedName
 import jp.shiguredo.sora.sdk.util.SDKInfo
+import org.webrtc.RtpParameters
 
 // NOTE: 後方互換性を考慮して、項目を追加するときはオプショナルで定義するようにしてください。
 
@@ -96,18 +97,13 @@ data class OfferConfig(
     @SerializedName("iceTransportPolicy") val iceTransportPolicy: String
 )
 
-data class ScaleResolutionDownTo(
-    @SerializedName("maxWidth") var maxWidth: Int,
-    @SerializedName("maxHeight") var maxHeight: Int
-)
-
 data class Encoding(
     @SerializedName("rid") val rid: String?,
     @SerializedName("active") val active: Boolean?,
     @SerializedName("maxBitrate") val maxBitrate: Int?,
     @SerializedName("maxFramerate") val maxFramerate: Double?,
     @SerializedName("scaleResolutionDownBy") val scaleResolutionDownBy: Double?,
-    @SerializedName("scaleResolutionDownTo") val scaleResolutionDownTo: ScaleResolutionDownTo?,
+    @SerializedName("scaleResolutionDownTo") val scaleResolutionDownTo: RtpParameters.ResolutionRestriction?,
     @SerializedName("scalabilityMode") val scalabilityMode: String?
 )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -96,12 +96,18 @@ data class OfferConfig(
     @SerializedName("iceTransportPolicy") val iceTransportPolicy: String
 )
 
+data class ScaleResolutionDownTo (
+    @SerializedName("width") var width: Int,
+    @SerializedName("height") var height: Int
+)
+
 data class Encoding(
     @SerializedName("rid") val rid: String?,
     @SerializedName("active") val active: Boolean?,
     @SerializedName("maxBitrate") val maxBitrate: Int?,
     @SerializedName("maxFramerate") val maxFramerate: Double?,
     @SerializedName("scaleResolutionDownBy") val scaleResolutionDownBy: Double?,
+    @SerializedName("scaleResolutionDownTo") val scaleResolutionDownTo: ScaleResolutionDownTo?,
     @SerializedName("scalabilityMode") val scalabilityMode: String?
 )
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -97,8 +97,8 @@ data class OfferConfig(
 )
 
 data class ScaleResolutionDownTo(
-    @SerializedName("width") var width: Int,
-    @SerializedName("height") var height: Int
+    @SerializedName("maxWidth") var maxWidth: Int,
+    @SerializedName("maxHeight") var maxHeight: Int
 )
 
 data class Encoding(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -96,7 +96,7 @@ data class OfferConfig(
     @SerializedName("iceTransportPolicy") val iceTransportPolicy: String
 )
 
-data class ScaleResolutionDownTo (
+data class ScaleResolutionDownTo(
     @SerializedName("width") var width: Int,
     @SerializedName("height") var height: Int
 )


### PR DESCRIPTION
- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する

---

This pull request includes updates to the `sora-android-sdk` to add new functionality for video encoding parameters and some minor improvements to the codebase. The most important changes are as follows:

### New Functionality

* Added `scaleResolutionDownTo` parameter to the `Encoding` data class to support simulating video encoding parameters. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`)
* Updated the `PeerChannelImpl` class to utilize the new `scaleResolutionDownTo` parameter. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt`)

### Documentation

* Updated `CHANGES.md` to reflect the addition of the `scaleResolutionDownTo` parameter. (`CHANGES.md`)

### Codebase Improvements

* Imported `org.webrtc.RtpParameters` in `Catalog.kt` to support the new `scaleResolutionDownTo` parameter. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`)