### PR TITLE
type:notify のメッセージ項目を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,14 @@
     - SignalingChannelImpl
     - ConnectMessage (Any で定義されているが、実態は SoraForwardingFilterOption を Map に変換したもの)
   - @zztkm
+- [UPDATE] NotificationMessage に項目を追加する
+  - 追加した項目
+    - `timestamp`
+    - `spotlightNumber`
+    - `failedConnectionId`
+    - `currentState`
+    - `previousState`
+  - @zztkm
 - [ADD] 転送フィルター機能の設定を表すクラス `SoraForwardingFilterOption` に `name` と `priority` を追加する
   - @zztkm
 - [ADD] 転送フィルターをリスト形式で指定するためのプロパティを追加する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -187,11 +187,13 @@ data class StatsMessage(
 data class NotificationMessage(
     @SerializedName("type") val type: String = "notify",
     @SerializedName("event_type") val eventType: String,
+    @SerializedName("timestamp") val timestamp: String,
     @SerializedName("role") val role: String?,
     @SerializedName("session_id") val sessionId: String?,
     @SerializedName("client_id") val clientId: String?,
     @SerializedName("bundle_id") val bundleId: String?,
     @SerializedName("connection_id") val connectionId: String?,
+    @SerializedName("spotlight_number") val spotlightNumber: Int?,
     @SerializedName("audio") val audio: Boolean?,
     @SerializedName("video") val video: Boolean?,
     @SerializedName("metadata") val metadata: Any?,
@@ -213,6 +215,9 @@ data class NotificationMessage(
     @SerializedName("recv_connection_id") val recvConnectionId: String?,
     @SerializedName("send_connection_id") val sendConnectionId: String?,
     @SerializedName("stream_id") val streamId: String?,
+    @SerializedName("failed_connection_id") val failedConnectionId: String?,
+    @SerializedName("current_state") val currentState: String?,
+    @SerializedName("previous_state") val previousState: String?,
 )
 
 data class DisconnectMessage(


### PR DESCRIPTION
- [UPDATE] NotificationMessage に項目を追加する
  - 追加した項目
    - `timestamp`
    - `spotlightNumber`
    - `failedConnectionId`
    - `currentState`
    - `previousState`
  
---

This pull request includes updates to the `NotificationMessage` class and the associated documentation. The changes primarily focus on adding new fields to the `NotificationMessage` class to enhance its functionality.

Updates to `NotificationMessage` class:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880R190-R196): Added new fields `timestamp`, `spotlightNumber`, `failedConnectionId`, `currentState`, and `previousState` to the `NotificationMessage` class. [[1]](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880R190-R196) [[2]](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880R218-R220)

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R38-R45): Updated the change log to reflect the addition of new fields to the `NotificationMessage` class.