### PR TITLE
CHANGSE に記載の OfferMessage 追加した項目名をキャメルケースに修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,16 +17,16 @@
   - 追加した項目
     - `version`
     - `multistream`
-    - `simulcast_multicodec`
+    - `simulcastMulticodec`
     - `spotlight`
-    - `channel_id`
-    - `session_id`
+    - `channelId`
+    - `sessionId`
     - `audio`
-    - `audio_codec_type`
-    - `audio_bit_rate`
+    - `audioCodecType`
+    - `audioBitRate`
     - `video`
-    - `video_codec_type`
-    - `video_bit_rate`
+    - `videoCodecType`
+    - `videoBitRate`
   - @zztkm
 - [UPDATE] SoraForwardingFilterOption 型の引数を Sora での 2025 年 12 月の廃止に向けて非推奨にする
   - 今後はリスト形式の転送フィルター設定を利用してもらう


### PR DESCRIPTION
変更内容

OfferMessage に追加した項目と記載しているのに、項目の記載が offer message の json の項目名だったので、OfferMessage data class での項目名に修正しました。

リリース前の CHANGES の修正なので、この PR での CHANGES 追加はありません。

---

This pull request includes updates to the `CHANGES.md` file to standardize the naming conventions of several parameters. The most important changes are as follows:

Parameter naming standardization:

* Changed `simulcast_multicodec` to `simulcastMulticodec`.
* Changed `channel_id` to `channelId`.
* Changed `session_id` to `sessionId`.
* Changed `audio_codec_type` to `audioCodecType`.
* Changed `audio_bit_rate` to `audioBitRate`.
* Changed `video_codec_type` to `videoCodecType`.
* Changed `video_bit_rate` to `videoBitRate`.