### PR TITLE
OfferMessage の multistream を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,6 @@
 - [UPDATE] OfferMessage に項目を追加する
   - 追加した項目
     - `version`
-    - `multistream`
     - `simulcastMulticodec`
     - `spotlight`
     - `channelId`

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -115,7 +115,6 @@ data class OfferMessage(
     @SerializedName("sdp") val sdp: String,
     @SerializedName("version") val version: String? = null,
 
-    @SerializedName("multistream") val multistream: Boolean? = null,
     @SerializedName("simulcast") val simulcast: Boolean = false,
     @SerializedName("simulcast_multicodec") val simulcastMulticodec: Boolean? = null,
     @SerializedName("spotlight") val spotlight: Boolean? = null,


### PR DESCRIPTION
リリース前の項目調整のため、CHANGES は書いていません。

---
This pull request includes changes to the `OfferMessage` class and its documentation. The most important changes involve updating the `OfferMessage` class to remove the `multistream` field and updating the `CHANGES.md` file accordingly.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L19): Removed the `multistream` field from the list of added items in the `OfferMessage` section.

Code updates:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`](diffhunk://#diff-a975bcd15426cebd3d232963e11d104f29068ef1ad9ea9ca12a8eb695e81d880L118): Removed the `multistream` field from the `OfferMessage` data class.