### PR TITLE
libwebrtc を m132.6834.5.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [UPDATE] libwebrtc を 131.6778.4.0 に上げる
+- [UPDATE] libwebrtc を 132.6834.5.0 に上げる
   - @miosakuma @zztkm
 - [UPDATE] OfferMessage に項目を追加する
   - 追加した項目

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sora Android SDK
 
 [![Release](https://jitpack.io/v/shiguredo/sora-android-sdk.svg)](https://jitpack.io/#shiguredo/sora-android-sdk)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-131.6778-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6834)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-132.6834-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6834)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/shiguredo/sora-android-sdk.svg)](https://github.com/shiguredo/sora-android-sdk.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sora Android SDK
 
 [![Release](https://jitpack.io/v/shiguredo/sora-android-sdk.svg)](https://jitpack.io/#shiguredo/sora-android-sdk)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-131.6778-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6778)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-131.6778-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6834)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/shiguredo/sora-android-sdk.svg)](https://github.com/shiguredo/sora-android-sdk.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.libwebrtc_version = '131.6778.4.0'
+    ext.libwebrtc_version = '132.6834.5.0'
 
     ext.dokka_version = '1.8.10'
 


### PR DESCRIPTION
- [UPDATE] libwebrtc を 132.6834.5.0 に上げる

---

This pull request includes updates to the `libwebrtc` version used in the project. The most important changes include updating the version number in both the `CHANGES.md` and `README.md` files.

Version updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R14): Updated `libwebrtc` version from `131.6778.4.0` to `132.6834.5.0`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated the `libwebrtc` badge link to reflect the new version.