### PR TITLE
Canary Release 用スクリプトの canary.py を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,8 @@
 - [UPDATE] システム条件を更新する
   - Android Studio 2024.1.2 以降
   - @miosakuma
+- [ADD] Canary Release 用スクリプトの canary.py を追加する
+  - @zztkm
 
 ## 2024.3.1
 

--- a/canary.py
+++ b/canary.py
@@ -2,8 +2,6 @@ import argparse
 import re
 import subprocess
 
-# 更新対象のPackageInfoファイル
-PACKAGEINFO_FILE = "Sora/PackageInfo.swift"
 
 SDKINFO_FILE = "sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/SDKInfo.kt"
 
@@ -132,7 +130,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # PackageInfoファイルを読み込んでバージョンを更新
+    # SDKInfo.kt を読み込んでバージョンを更新
     with open(SDKINFO_FILE, "r") as file:
         packageinfo_content = file.readlines()
     updated_packageinfo_content, new_version = update_sdkinfo_version(

--- a/canary.py
+++ b/canary.py
@@ -1,0 +1,148 @@
+import argparse
+import re
+import subprocess
+
+# 更新対象のPackageInfoファイル
+PACKAGEINFO_FILE = "Sora/PackageInfo.swift"
+
+SDKINFO_FILE = "sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/SDKInfo.kt"
+
+
+def update_sdkinfo_version(packageinfo_content):
+    """
+    SDKInfo.ktファイルの内容からバージョンを更新する
+
+    Args:
+        packageinfo_content (list): SDKInfo.ktファイルの各行を要素とするリスト
+
+    Returns:
+        tuple: (更新後のファイル内容のリスト, 新しいバージョン文字列)
+
+    Raises:
+        ValueError: バージョン指定が見つからない場合
+    """
+    updated_content = []
+    sdk_version_updated = False
+    new_version = None
+
+    for line in packageinfo_content:
+        line = line.rstrip()  # 末尾の改行のみを削除
+        if "const val version" in line:
+            # バージョン行のパターンマッチング
+            version_match = re.match(
+                r'\s*const\s+val\s+version\s*=\s*[\'"](\d+\.\d+\.\d+)(-canary\.(\d+))?[\'"]',
+                line,
+            )
+            if version_match:
+                major_minor_patch = version_match.group(1)  # 基本バージョン (例: 1.0.0)
+                canary_suffix = version_match.group(2)  # canaryサフィックス部分
+
+                # canaryサフィックスが無い場合は.0から開始、ある場合は番号をインクリメント
+                if canary_suffix is None:
+                    new_version = f"{major_minor_patch}-canary.0"
+                else:
+                    canary_number = int(version_match.group(3))
+                    new_version = f"{major_minor_patch}-canary.{canary_number + 1}"
+
+                # SDKInfoのバージョン行を更新
+                updated_content.append(f'        const val version = "{new_version}"')
+                sdk_version_updated = True
+            else:
+                updated_content.append(line)
+        else:
+            updated_content.append(line)
+
+    if not sdk_version_updated:
+        raise ValueError("Version specification not found in SDKInfo.kt file.")
+
+    return updated_content, new_version
+
+
+def write_file(filename, updated_content, dry_run):
+    """
+    更新後の内容をファイルに書き込む
+
+    Args:
+        filename (str): 書き込み対象のファイル名
+        updated_content (list): 更新後のファイル内容
+        dry_run (bool): True の場合は実際の書き込みを行わない
+    """
+    if dry_run:
+        print(f"Dry run: The following changes would be written to {filename}:")
+        print("\n".join(updated_content))
+    else:
+        with open(filename, "w") as file:
+            file.write("\n".join(updated_content) + "\n")
+        print(f"{filename} updated.")
+
+
+def git_operations(new_version, dry_run):
+    """
+    Git操作（コミット、タグ付け、プッシュ）を実行
+
+    Args:
+        new_version (str): 新しいバージョン文字列（タグとして使用）
+        dry_run (bool): True の場合は実際のGit操作を行わない
+    """
+    commit_message = f"[canary] Update SDKInfo.kt version to {new_version}"
+
+    if dry_run:
+        # dry-run時は実行されるコマンドを表示のみ
+        print(f"Dry run: Would execute git add {SDKINFO_FILE}")
+        print(f"Dry run: Would execute git commit -m '{commit_message}'")
+        print(f"Dry run: Would execute git tag {new_version}")
+        print(f"Dry run: Would execute git push origin develop")
+        print(f"Dry run: Would execute git push origin {new_version}")
+    else:
+        # ファイルをステージング
+        print(f"Executing: git add {SDKINFO_FILE}")
+        subprocess.run(["git", "add", SDKINFO_FILE], check=True)
+
+        # 変更をコミット
+        print(f"Executing: git commit -m '{commit_message}'")
+        subprocess.run(["git", "commit", "-m", commit_message], check=True)
+
+        # バージョンタグを作成
+        print(f"Executing: git tag {new_version}")
+        subprocess.run(["git", "tag", new_version], check=True)
+
+        # developブランチをプッシュ
+        print("Executing: git push origin develop")
+        subprocess.run(["git", "push", "origin", "develop"], check=True)
+
+        # タグをプッシュ
+        print(f"Executing: git push origin {new_version}")
+        subprocess.run(["git", "push", "origin", new_version], check=True)
+
+
+def main():
+    """
+    メイン処理:
+    1. コマンドライン引数の解析
+    2. SDKInfo.kt ファイルの読み込みと更新
+    3. Git操作の実行
+    """
+    parser = argparse.ArgumentParser(
+        description="Update SDKInfo.kt version and push changes with git."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform a dry run without making any changes.",
+    )
+    args = parser.parse_args()
+
+    # PackageInfoファイルを読み込んでバージョンを更新
+    with open(SDKINFO_FILE, "r") as file:
+        packageinfo_content = file.readlines()
+    updated_packageinfo_content, new_version = update_sdkinfo_version(
+        packageinfo_content
+    )
+    write_file(SDKINFO_FILE, updated_packageinfo_content, args.dry_run)
+
+    # Git操作の実行
+    git_operations(new_version, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [ADD] Canary Release 用スクリプトの canary.py を追加する

---

This pull request introduces a new script for managing Canary Releases and updates the `CHANGES.md` file to reflect this addition. The most important changes include the addition of the `canary.py` script and the corresponding update in the `CHANGES.md` file.

### New Script Addition:

* [`canary.py`](diffhunk://#diff-fd6b27a658789411410f2666ae3850222386bb3160a8a5f67a7e10e983bf251aR1-R148): Added a new script to automate the process of updating the version in `SDKInfo.kt`, committing the changes, tagging the new version, and pushing the changes to the repository. The script supports a dry-run mode for testing purposes.

### Documentation Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R73-R74): Updated to include the addition of the `canary.py` script for Canary Releases.