### PR TITLE
libwebrtc を m132.6834.5.3 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] libwebrtc を 132.6834.5.3 に上げる
+  - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
   - `SoraMediaOption.enableSpotlight` を実行したときに multistream を true にする処理を削除
   - `ConnectMessage` 初期化時に渡す multistream の値を `SoraMediaOption.multistreamEnabled` に変更

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.libwebrtc_version = '132.6834.5.0'
+    ext.libwebrtc_version = '132.6834.5.3'
 
     ext.dokka_version = '1.8.10'
 


### PR DESCRIPTION
※ branch-heads は変わっていないので、README は今回は更新不要

- [UPDATE] libwebrtc を 132.6834.5.3 に上げる

---

This pull request includes updates to the `CHANGES.md` file. The most important change is the update to the `libwebrtc` library version.

* Updated `libwebrtc` to version 132.6834.5.3 (`CHANGES.md`)