### PR TITLE
SoraMediaChannel.Listener.onCloseの呼び出しタイミングを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
+- [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する
+  - 説明には「Sora との接続が切断されたときに呼び出される」と記載していたが、実際には切断処理が完了する前に呼び出していたので、説明に合わせて修正を行った
+  - @zztkm
 
 ## 2025.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する
-  - 説明には「Sora との接続が切断されたときに呼び出される」と記載していたが、実際には切断処理が完了する前に呼び出していたので、説明に合わせて修正
+  - 切断処理が終了する前に `onClose` を呼び出していたため、切断処理が完了してから呼び出すように修正
   - `contactSignalingEndpoint` と `connectedSignalingEndpoint` は onClose で参照される可能性があるため、onClose 実行よりあとに null になるように onClose に合わせて処理順を変更
   - @zztkm
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,8 @@
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する
-  - 説明には「Sora との接続が切断されたときに呼び出される」と記載していたが、実際には切断処理が完了する前に呼び出していたので、説明に合わせて修正を行った
+  - 説明には「Sora との接続が切断されたときに呼び出される」と記載していたが、実際には切断処理が完了する前に呼び出していたので、説明に合わせて修正
+  - `contactSignalingEndpoint` と `connectedSignalingEndpoint` は onClose で参照される可能性があるため、onClose 実行よりあとに null になるように onClose に合わせて処理順を変更
   - @zztkm
 
 ## 2025.1.0

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -957,9 +957,6 @@ class SoraMediaChannel @JvmOverloads constructor(
         }
         compositeDisposable.dispose()
 
-        listener?.onClose(this)
-        listener = null
-
         // アプリケーションで定義された切断処理を実行した後に contactSignalingEndpoint と connectedSignalingEndpoint を null にする
         contactSignalingEndpoint = null
         connectedSignalingEndpoint = null
@@ -974,6 +971,9 @@ class SoraMediaChannel @JvmOverloads constructor(
         // 既に type: disconnect を送信しているので、 disconnectReason は null で良い
         peer?.disconnect(null)
         peer = null
+
+        listener?.onClose(this)
+        listener = null
     }
 
     private fun sendDisconnectOverWebSocket(disconnectReason: SoraDisconnectReason) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -957,10 +957,6 @@ class SoraMediaChannel @JvmOverloads constructor(
         }
         compositeDisposable.dispose()
 
-        // アプリケーションで定義された切断処理を実行した後に contactSignalingEndpoint と connectedSignalingEndpoint を null にする
-        contactSignalingEndpoint = null
-        connectedSignalingEndpoint = null
-
         // 既に type: disconnect を送信しているので、 disconnectReason は null で良い
         signaling?.disconnect(null)
         signaling = null
@@ -974,6 +970,10 @@ class SoraMediaChannel @JvmOverloads constructor(
 
         listener?.onClose(this)
         listener = null
+
+        // onClose によってアプリケーションで定義された切断処理を実行した後に contactSignalingEndpoint と connectedSignalingEndpoint を null にする
+        contactSignalingEndpoint = null
+        connectedSignalingEndpoint = null
     }
 
     private fun sendDisconnectOverWebSocket(disconnectReason: SoraDisconnectReason) {


### PR DESCRIPTION
- [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する
  - 説明には「Sora との接続が切断されたときに呼び出される」と記載していたが、実際には切断処理が完了する前に呼び出していたので、説明に合わせて修正を行った

---

This pull request includes changes to the `SoraMediaChannel` class to ensure that the `onClose` listener is called after the disconnection process is fully completed. Additionally, the `CHANGES.md` file has been updated to reflect this fix.

Changes to disconnection process:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L960-L962): Moved the call to `listener?.onClose(this)` and setting `listener` to `null` to occur after the disconnection process is fully completed. [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L960-L962) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R974-R976)

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R28-R29): Added a fix entry to document the change in the timing of the `SoraMediaChannel.Listener.onClose` call to occur after the disconnection process is fully completed.