### PR TITLE
[WIP] SignalingChannelImpl の WebSocketListener.onClosing では disconnect メソッドを呼ばないようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,13 @@
 - [UPDATE] `SoraMediaOption` に `enableLegacyStream` を追加する
   - レガシーストリームのための関数だが、レガシーストリームは廃止予定なので最初から非推奨にしている
   - @zztkm
+- [UPDATE] SignalingChannelImpl の WebSocketListener.onClosing では disconnect メソッドを呼ばないようにする
+  - onClosing が呼ばれてから onClosed が呼ばれるまでは WebSocket メッセージを送信中である可能性があるため
+  - disconnect を onClosing で呼び出すより、onClosed でだけ呼び出すようにするほうが安全であった。
+  - そこで、onClosed のみで disconnect メソッドを呼ぶようにしても問題がないか OkHttp 4.12.0 の実装を確認したところ、
+  - ネットワーク問題などの異常が発生しない場合は onClosed が必ず呼ばれ、onClosing で disconnect メソッドを呼ぶ必要がないことがわかったため
+  - disconnect メソッドを onClosing で呼び出す処理を削除した。
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -364,7 +364,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
         listener?.onRedirect(msg.location)
     }
 
-    // WebSocketListener の onClosed, onClosing, onFailure で使用する
+    // WebSocketListener の onClosed, onFailure で使用する
     @Synchronized
     private fun propagatesWebSocketTerminateEventToSignalingChannel(webSocket: WebSocket): Boolean {
         // 接続状態になる可能性がなくなった WebSocket を wsCandidates から削除
@@ -462,6 +462,9 @@ class SignalingChannelImpl @JvmOverloads constructor(
             // This time, we don't use byte-data, so ignore this message
         }
 
+        /**
+         * 接続が正常終了したときに呼び出される.
+         */
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
             if (code == 1000) {
                 SoraLogger.i(TAG, "[signaling:$role] @onClosed: reason = [$reason], code = $code")
@@ -476,6 +479,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
             try {
                 if (code != 1000) {
+                    // TODO(zztkm): WebSocketListener.onFailure で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
                     listener?.onError(SoraErrorReason.SIGNALING_FAILURE)
                 }
 
@@ -485,17 +489,21 @@ class SignalingChannelImpl @JvmOverloads constructor(
             }
         }
 
+        /**
+         * サーバーから Close フレームを受信したときに呼び出される.
+         *
+         * NOTE: OkHttp (4.12.0) の実装を確認したところ、異常が発生しなければ onClosed が必ず呼ばれるため
+         * onClosing では終了処理を行わず、debug ログを出力するのみとしている (異常発生時は onFailure が呼ばれる).
+         *
+         * もし onClosing だけ呼ばれるような事象を特定したときは、onClosing での終了処理を検討する.
+         */
         override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
             SoraLogger.d(TAG, "[signaling:$role] @onClosing: = [$reason], code = $code")
-
-            if (!propagatesWebSocketTerminateEventToSignalingChannel(webSocket)) {
-                SoraLogger.d(TAG, "[signaling:$role] @onClosing: skipped")
-                return
-            }
-
-            disconnect(SoraDisconnectReason.WEBSOCKET_ONCLOSE)
         }
 
+        /**
+         * ネットワーク関連の問題が発生し、WebSocket が閉じられたときに呼び出される.
+         */
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
             response?.let {
                 SoraLogger.i(TAG, "[signaling:$role] @onFailure: ${it.message}, $t")
@@ -507,6 +515,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
             }
 
             try {
+                // TODO(zztkm): WebSocketListener.onClose で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
                 listener?.onError(SoraErrorReason.SIGNALING_FAILURE)
                 disconnect(SoraDisconnectReason.WEBSOCKET_ONERROR)
             } catch (e: Exception) {


### PR DESCRIPTION
- [UPDATE] SignalingChannelImpl の WebSocketListener.onClosing では disconnect メソッドを呼ばないようにする
  - onClosing が呼ばれてから onClosed が呼ばれるまでは WebSocket メッセージを送信中である可能性があるため
  - disconnect を onClosing で呼び出すより、onClosed でだけ呼び出すようにするほうが安全であった。
  - そこで、onClosed のみで disconnect メソッドを呼ぶようにしても問題がないか OkHttp 4.12.0 の実装を確認したところ、
  - ネットワーク問題などの異常が発生しない場合は onClosed が必ず呼ばれ、onClosing で disconnect メソッドを呼ぶ必要がないことがわかったため
  - disconnect メソッドを onClosing で呼び出す処理を削除した。

---

This pull request includes several changes to the `SignalingChannelImpl` class in the `sora-android-sdk` to improve the handling of WebSocket events and error propagation. The most important changes include modifications to the `onClosing` and `onClosed` methods to ensure safer disconnect handling, and the addition of comments and TODOs for better code clarity and future improvements.

### Changes to WebSocket event handling:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt`](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R492-R506): Modified the `onClosing` method to remove the call to the `disconnect` method, ensuring that `disconnect` is only called in the `onClosed` method for safer handling. Added detailed comments explaining the rationale behind this change. [[1]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R492-R506) [[2]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R518)
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt`](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R465-R467): Added comments to the `onClosed` and `onFailure` methods to describe their purpose and behavior, enhancing code readability. [[1]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R465-R467) [[2]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R482)

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R26-R32): Updated the change log to include the modification to the `SignalingChannelImpl` class, specifically noting that the `disconnect` method is no longer called in the `onClosing` method to prevent potential issues with WebSocket message transmission.