### PR TITLE
[WIP] `SoraMediaChannel.Listener` に切断処理の結果 `SoraCloseResult` を取得できるコールバック `onClose` を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
   - `WebSocketListener.onClosed` で取得できる code と reason を`SignalingDisconnectResult` に格納して返すようにした
   - code と reason が取得できない場合は null を返すようにした
   - @zztkm
+- [UPDATE] `SoraMediaChannel.Listener` に切断処理の結果 `SoraCloseResult` を取得できるコールバック `onClose` を追加する
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@
   - onClosed のみで disconnect メソッドを呼ぶようにしても問題がないか OkHttp 4.12.0 の実装を確認したところ、ネットワーク問題などの異常が発生しない場合は onClosed が必ず呼び出されることがわかった
   - onClosing で disconnect メソッドを呼ぶ必要がないことがわかったため、disconnect メソッドを onClosing で呼び出す処理を削除した
   - @zztkm
+- [UPDATE] `SignalingChannelImpl.disconnect` 内で WebSocketListener の onClosed が上がってくるのを待つようにする
+  - onClosed が 5 秒以内に呼ばれない場合はタイムアウト処理を行う
+  - onClosed を待つことで WebSocket Close Frame に含まれる code と reason を取得できるようになる
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,10 @@
   - onClosed が 5 秒以内に呼ばれない場合はタイムアウト処理を行う
   - onClosed を待つことで WebSocket Close Frame に含まれる code と reason を取得できるようになる
   - @zztkm
+- [UPDATE] SignalingChannelImpl の `disconenct` の返り値を `SignalingDisconnectResult?` に変更する
+  - `WebSocketListener.onClosed` で取得できる code と reason を`SignalingDisconnectResult` に格納して返すようにした
+  - code と reason が取得できない場合は null を返すようにした
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
@@ -1,0 +1,6 @@
+package jp.shiguredo.sora.sdk.channel
+
+data class SoraCloseResult(
+    val code: Int,
+    val reason: String,
+)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -11,8 +11,13 @@ import jp.shiguredo.sora.sdk.channel.signaling.message.SwitchedMessage
 import jp.shiguredo.sora.sdk.error.SoraDisconnectReason
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -79,6 +84,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
     companion object {
         private val TAG = SignalingChannelImpl::class.simpleName
+        private const val DISCONNECT_TIMEOUT_MS = 5000L // 5 秒のタイムアウト
     }
 
     private val client: OkHttpClient
@@ -142,6 +148,10 @@ class SignalingChannelImpl @JvmOverloads constructor(
     private val closing = AtomicBoolean(false)
 
     private val receivedRedirectMessage = AtomicBoolean(false)
+
+    // disconnect したときに WebSocketListener.onClosed が呼ばれるまで待機するために利用する
+    private val mutex = Mutex()
+    private var connectionClosed = false
 
     override fun connect() {
         SoraLogger.i(TAG, "[signaling:$role] endpoints=$endpoints")
@@ -236,13 +246,39 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
         closing.set(true)
         client.dispatcher.executorService.shutdown()
-        ws?.close(1000, null)
 
-        // type: redirect を受信している場合は onDisconnect を発火させない
-        if (!receivedRedirectMessage.get()) {
-            listener?.onDisconnect(disconnectReason)
+        val webSocket = ws
+        if (webSocket != null) {
+            webSocket.close(1000, null)
+
+            // WebSocketのcloseが完了するのを待つ
+            return runBlocking(Dispatchers.IO) {
+                try {
+                    // onClosedが呼ばれるのを最大DISCONNECT_TIMEOUT_MSミリ秒待つ
+                    withTimeout(DISCONNECT_TIMEOUT_MS) {
+                        // connectionClosedがtrueになるまで待機
+                        while (!connectionClosed) {
+                            kotlinx.coroutines.delay(100)
+                        }
+                    }
+                } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+                    SoraLogger.w(TAG, "[signaling:$role] Timed out waiting for WebSocket to close")
+                } finally {
+                    // type: redirect を受信している場合は onDisconnect を発火させない
+                    if (!receivedRedirectMessage.get()) {
+                        listener?.onDisconnect(disconnectReason)
+                    }
+                    listener = null
+                }
+            }
+        } else {
+            // WebSocketが存在しない場合は即座に終了
+            // type: redirect を受信している場合は onDisconnect を発火させない
+            if (!receivedRedirectMessage.get()) {
+                listener?.onDisconnect(disconnectReason)
+            }
+            listener = null
         }
-        listener = null
     }
 
     private fun sendConnectMessage() {
@@ -477,15 +513,19 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 return
             }
 
-            try {
-                if (code != 1000) {
-                    // TODO(zztkm): WebSocketListener.onFailure で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
-                    listener?.onError(SoraErrorReason.SIGNALING_FAILURE)
+            CoroutineScope(Dispatchers.IO).launch {
+                mutex.withLock {
+                    connectionClosed = true
+                    try {
+                        if (code != 1000) {
+                            // TODO(zztkm): WebSocketListener.onFailure で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
+                            listener?.onError(SoraErrorReason.SIGNALING_FAILURE)
+                        }
+                        disconnect(SoraDisconnectReason.WEBSOCKET_ONCLOSE)
+                    } catch (e: Exception) {
+                        SoraLogger.w(TAG, e.toString())
+                    }
                 }
-
-                disconnect(SoraDisconnectReason.WEBSOCKET_ONCLOSE)
-            } catch (e: Exception) {
-                SoraLogger.w(TAG, e.toString())
             }
         }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -84,6 +84,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
     companion object {
         private val TAG = SignalingChannelImpl::class.simpleName
+        // TODO(zztkm): タイムアウト値を外部から設定できるようにするか検討する
         private const val DISCONNECT_TIMEOUT_MS = 5000L // 5 秒のタイムアウト
     }
 
@@ -252,6 +253,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
             webSocket.close(1000, null)
 
             // WebSocketのcloseが完了するのを待つ
+            // TODO(zztkm): main スレッドをブロックしてる可能性があるので、問題がないか確認する
             return runBlocking(Dispatchers.IO) {
                 try {
                     // onClosedが呼ばれるのを最大DISCONNECT_TIMEOUT_MSミリ秒待つ

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
@@ -1,0 +1,6 @@
+package jp.shiguredo.sora.sdk.channel.signaling
+
+data class SignalingChannelDisconnectResult(
+    val code: Int,
+    val reason: String
+)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
@@ -1,6 +1,6 @@
 package jp.shiguredo.sora.sdk.channel.signaling
 
-data class SignalingChannelDisconnectResult(
+internal data class SignalingChannelDisconnectResult(
     val code: Int,
     val reason: String
 )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
@@ -1,6 +1,6 @@
 package jp.shiguredo.sora.sdk.channel.signaling
 
-internal data class SignalingChannelDisconnectResult(
+data class SignalingChannelDisconnectResult(
     val code: Int,
     val reason: String
 )


### PR DESCRIPTION
- [UPDATE] `SoraMediaChannel.Listener` に切断処理の結果 `SoraCloseResult` を取得できるコールバック `onClose` を追加する
