### PR TITLE
`SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,7 +38,7 @@
   - WebSocket シグナリングの切断結果を表す `SignalingChannelDisconnectResult` を追加した
   - @zztkm
 - [UPDATE] `SignalingChannelImpl` の `WebSocketListener.onClosed` の処理で WebSocket ステータスコードが 1000 以外の場合に onError を呼び出さないようにする
-  - 2025.1.0 までも onError のコールバック呼び出しが定義されていましたが、onClosing が実行された時点で SignalingChannelImpl の listener の参照が削除される影響で、onError は呼び出されなかったため SDK ユーザーには影響がない
+  - 2025.1.0 まで onError のコールバック呼び出しが定義されていたが、実際は onClosing が実行された時点で SignalingChannelImpl の listener の参照が削除され、onError は呼び出されなかったため動作に変更はない
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@
     - 引用元: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
   - この修正は Sora との内部的なやり取り部分にのみ影響するため、SDK ユーザーへの影響はない
   - @zztkm
+- [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
   - この修正は Sora との内部的なやり取り部分にのみ影響するため、SDK ユーザーへの影響はない
   - @zztkm
 - [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
+  - Sora からの切断結果を表す `SoraCloseResult` を追加した
+  - WebSocket シグナリングの切断結果を表す `SignalingChannelDisconnectResult` を追加した
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,12 @@
 
 ## develop
 
-- [UPDATE] libwebrtc を 132.6834.5.3 に上げる
-  - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
   - `SoraMediaOption.enableSpotlight` を実行したときに multistream を true にする処理を削除
   - `ConnectMessage` 初期化時に渡す multistream の値を `SoraMediaOption.multistreamEnabled` に変更
     - `SoraMediaOption.multistreamIsRequired` 利用しなくなったので削除
+  - @zztkm
+- [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする
   - @zztkm
@@ -36,6 +36,9 @@
 - [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
   - Sora からの切断結果を表す `SoraCloseResult` を追加した
   - WebSocket シグナリングの切断結果を表す `SignalingChannelDisconnectResult` を追加した
+  - @zztkm
+- [UPDATE] `SignalingChannelImpl` の `WebSocketListener.onClosed` の処理で WebSocket ステータスコードが 1000 以外の場合に onError を呼び出さないようにする
+  - 2025.1.0 までも onError のコールバック呼び出しが定義されていましたが、onClosing が実行された時点で SignalingChannelImpl の listener の参照が削除される影響で、onError は呼び出されなかったため SDK ユーザーには影響がない
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
@@ -1,5 +1,11 @@
 package jp.shiguredo.sora.sdk.channel
 
+/**
+ * SoraCloseResult は Sora から接続が切断された際の結果を表します。
+ *
+ * @param code 切断時のステータスコード
+ * @param reason 切断理由
+ */
 data class SoraCloseResult(
     val code: Int,
     val reason: String,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt
@@ -1,0 +1,6 @@
+package jp.shiguredo.sora.sdk.channel
+
+data class SoraCloseResult(
+    val code: Int,
+    val reason: String,
+)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -375,7 +375,7 @@ class SoraMediaChannel @JvmOverloads constructor(
 
     private var switchedToDataChannel = false
     // 切断処理を開始したことを示すフラグ
-    private var closing = AtomicBoolean(false)
+    private var closing = false
 
     // type: redirect で再利用するために、初回接続時の clientOffer を保持する
     private var clientOffer: SessionDescription? = null
@@ -702,7 +702,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             """.trimMargin()
         )
 
-        if (closing.get()) {
+        if (closing) {
             return
         }
         startTimer()
@@ -966,9 +966,9 @@ class SoraMediaChannel @JvmOverloads constructor(
     }
 
     private fun internalDisconnect(disconnectReason: SoraDisconnectReason?, closeResult: SoraCloseResult? = null) {
-        if (closing.get())
+        if (closing)
             return
-        closing.set(true)
+        closing = true
         SoraLogger.d(TAG, "[channel:$role] internalDisconnect: $disconnectReason")
 
         stopTimer()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -40,7 +40,6 @@ import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
 import java.util.Timer
 import java.util.TimerTask
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.schedule
 
 /**

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -989,7 +989,6 @@ class SoraMediaChannel @JvmOverloads constructor(
         peer = null
 
         listener?.onClose(this)
-        // ここでは closeResult が取得できないので null で良い
         listener?.onClose(this, closeResult)
         listener = null
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -374,6 +374,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     private var signaling: SignalingChannel? = null
 
     private var switchedToDataChannel = false
+    // 切断処理を開始したことを示すフラグ
     private var closing = AtomicBoolean(false)
 
     // type: redirect で再利用するために、初回接続時の clientOffer を保持する
@@ -965,7 +966,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     }
 
     /**
-     * クライアント側から切断する際に呼び出される切断処理.
+     * アプリケーションから切断する際に呼び出される切断処理.
      *
      * @param disconnectReason 切断理由
      */
@@ -973,6 +974,7 @@ class SoraMediaChannel @JvmOverloads constructor(
         if (closing.get())
             return
         closing.set(true)
+        SoraLogger.d(TAG, "[channel:$role] internalDisconnect: $disconnectReason")
 
         stopTimer()
         disconnectReason?.let {
@@ -1011,6 +1013,7 @@ class SoraMediaChannel @JvmOverloads constructor(
         if (closing.get())
             return
         closing.set(true)
+        SoraLogger.d(TAG, "[channel:$role] internalDisconnectFromSora: $disconnectReason")
 
         stopTimer()
         disconnectReason?.let {
@@ -1080,6 +1083,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             }
 
             SoraDisconnectReason.WEBSOCKET_ONCLOSE, SoraDisconnectReason.WEBSOCKET_ONERROR -> {
+                // DataChannel シグナリング利用かつ、WebSocket 切断を無視しない場合
                 if (switchedToDataChannel && !switchedIgnoreDisconnectWebSocket) {
                     sendDisconnectOverDataChannel(disconnectReason)
                 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -374,7 +374,6 @@ class SoraMediaChannel @JvmOverloads constructor(
     private var signaling: SignalingChannel? = null
 
     private var switchedToDataChannel = false
-    // TODO(zztkm): AtomicBoolean にすべきか確認・検討する
     private var closing = AtomicBoolean(false)
 
     // type: redirect で再利用するために、初回接続時の clientOffer を保持する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -236,7 +236,7 @@ class SoraMediaChannel @JvmOverloads constructor(
          *
          * @param mediaChannel イベントが発生したチャネル
          */
-        fun onClose(mediaChannel: SoraMediaChannel,) {}
+        fun onClose(mediaChannel: SoraMediaChannel) {}
 
         /**
          * Sora との通信やメディアでエラーが発生したときに呼び出されるコールバック.

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -488,16 +488,6 @@ class SignalingChannelImpl @JvmOverloads constructor(
             signalingChannelDisconnectResult.set(SignalingChannelDisconnectResult(code, reason))
 
             try {
-                // TODO(zztkm): 以下のコメント内容について対応を検討する
-                // Sora から切断されたときに code が 1000 以外（認証エラーなど）だと onError を起点にユーザーがアプリの切断処理を開始してしまい
-                // SoraMediaChannel.Listener.onClose を受け取る前に SoraMediaChannel インスタンスを破棄してしまう可能性があるため
-                // code != 1000 というだけで、WebSocket の onFailure （異常な切断）と同じように onError を呼び出すのは適切ではないかもしれない。
-                // これを改善しようとするとコールバックの使い方の破壊的変更になる可能性もあるので、慎重に検討する
-                if (code != 1000) {
-                    // TODO(zztkm): WebSocketListener.onFailure で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
-                    listener?.onError(SoraErrorReason.SIGNALING_FAILURE)
-                }
-
                 disconnect(SoraDisconnectReason.WEBSOCKET_ONCLOSE)
             } catch (e: Exception) {
                 SoraLogger.w(TAG, e.toString())

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -483,6 +483,11 @@ class SignalingChannelImpl @JvmOverloads constructor(
             signalingChannelDisconnectResult.set(SignalingChannelDisconnectResult(code, reason))
 
             try {
+                // TODO(zztkm): 以下のコメント内容について対応を検討する
+                // Sora から切断されたときに code が 1000 以外（認証エラーなど）だと onError を起点にユーザーがアプリの切断処理を開始してしまい
+                // SoraMediaChannel.Listener.onClose を受け取る前に SoraMediaChannel インスタンスを破棄してしまう可能性があるため
+                // code != 1000 というだけで、WebSocket の onFailure （異常な切断）と同じように onError を呼び出すのは適切ではないかもしれない。
+                // これを改善しようとするとコールバックの使い方の破壊的変更になる可能性もあるので、慎重に検討する
                 if (code != 1000) {
                     // TODO(zztkm): WebSocketListener.onFailure で呼び出す onError とはエラーの性質が異なるため、コールバックを分けることを検討する
                     listener?.onError(SoraErrorReason.SIGNALING_FAILURE)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 interface SignalingChannel {
 
@@ -40,7 +41,7 @@ interface SignalingChannel {
 
     interface Listener {
         fun onConnect(endpoint: String)
-        fun onDisconnect(disconnectReason: SoraDisconnectReason?)
+        fun onDisconnect(disconnectReason: SoraDisconnectReason?, result: SignalingChannelDisconnectResult?)
         fun onInitialOffer(offerMessage: OfferMessage, endpoint: String)
         fun onSwitched(switchedMessage: SwitchedMessage)
         fun onUpdatedOffer(sdp: String)
@@ -143,6 +144,8 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
     private val receivedRedirectMessage = AtomicBoolean(false)
 
+    private val signalingChannelDisconnectResult = AtomicReference<SignalingChannelDisconnectResult?>()
+
     override fun connect() {
         SoraLogger.i(TAG, "[signaling:$role] endpoints=$endpoints")
         synchronized(this) {
@@ -240,7 +243,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
 
         // type: redirect を受信している場合は onDisconnect を発火させない
         if (!receivedRedirectMessage.get()) {
-            listener?.onDisconnect(disconnectReason)
+            listener?.onDisconnect(disconnectReason, signalingChannelDisconnectResult.get())
         }
         listener = null
     }
@@ -476,6 +479,8 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 SoraLogger.d(TAG, "[signaling:$role] @onClosed: skipped")
                 return
             }
+
+            signalingChannelDisconnectResult.set(SignalingChannelDisconnectResult(code, reason))
 
             try {
                 if (code != 1000) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
@@ -1,0 +1,6 @@
+package jp.shiguredo.sora.sdk.channel.signaling
+
+data class SignalingChannelDisconnectResult(
+    val code: Int,
+    val reason: String,
+)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt
@@ -1,5 +1,11 @@
 package jp.shiguredo.sora.sdk.channel.signaling
 
+/**
+ * WebSocket シグナリングの切断結果を表します。
+ *
+ * @param code WebSocket 切断時のステータスコード
+ * @param reason WebSocket 切断理由
+ */
 data class SignalingChannelDisconnectResult(
     val code: Int,
     val reason: String,


### PR DESCRIPTION
- [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
  - Sora からの切断結果を表す `SoraCloseResult` を追加した
  - WebSocket シグナリングの切断結果を表す `SignalingChannelDisconnectResult` を追加した
- [UPDATE] `SignalingChannelImpl` の `WebSocketListener.onClosed` の処理で WebSocket ステータスコードが 1000 以外の場合に onError を呼び出さないようにする
  - 2025.1.0 までも onError のコールバック呼び出しが定義されていましたが、onClosing が実行された時点で SignalingChannelImpl の listener の参照が削除される影響で、onError は呼び出されなかったため SDK ユーザーには影響がない

---

This pull request includes several updates and improvements to the Sora Android SDK, primarily focusing on handling disconnection events and adding new features to the `SoraMediaChannel` and `SignalingChannel` classes. The most important changes are summarized below:

### Enhancements to Disconnection Handling:

* Added `SoraCloseResult` class to represent the result of a disconnection from Sora, including status code and reason. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseResult.kt`)
* Updated `SoraMediaChannel.Listener.onClose` method to include a `SoraCloseResult` parameter, allowing it to provide more detailed information about the disconnection. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`) [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R228-R240) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R992)
* Modified `SignalingChannelImpl` to set and pass a `SignalingChannelDisconnectResult` when a WebSocket disconnection occurs, providing detailed status code and reason. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt`)

### New Features:

* Added `onClose` method to `SoraMediaChannel.Listener` to retrieve the status code and reason when disconnected from Sora. (`CHANGES.md`)
* Introduced `SignalingChannelDisconnectResult` class to represent the result of a WebSocket disconnection in the signaling channel. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannelDisconnectResult.kt`)

### Codebase Simplification:

* Removed redundant `onClose` method without the `SoraCloseResult` parameter from `SoraMediaChannel.Listener`. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`)
* Added necessary imports and cleaned up unused imports in `SoraMediaChannel.kt`. (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`) [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R17) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R43)

These changes enhance the SDK's ability to handle disconnections more gracefully and provide more detailed information to the users about the disconnection events.