### PR TITLE
signaling label の type: close メッセージに対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,8 +43,8 @@
   - Sora から切断されたときに通知されるイベントである `SoraCloseEvent` を追加した
   - WebSocket シグナリング切断時に通知されるイベントである `SignalingChannelCloseEvent` を追加した
   - 以下の場合に、Sora から切断された際に `SoraCloseEvent` が通知される:
-    - WebSocket シグナリングを利用している場合
-    - DataChannel のみをシグナリングに利用する場合、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
+    - WebSocket 経由のシグナリングを利用している場合
+    - DataChannel 経由のシグナリングを利用する場合、かつ `ignore_disconnect_websocket` が true、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,8 +40,11 @@
   - この修正は Sora との内部的なやり取り部分にのみ影響するため、SDK ユーザーへの影響はない
   - @zztkm
 - [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
-  - Sora から切断した時に通知されるイベントである `SoraCloseEvent` を追加した
+  - Sora から切断されたときに通知されるイベントである `SoraCloseEvent` を追加した
   - WebSocket シグナリング切断時に通知されるイベントである `SignalingChannelCloseEvent` を追加した
+  - 以下の場合に、Sora から切断された際に `SoraCloseEvent` が通知される:
+    - WebSocket シグナリングを利用している場合
+    - DataChannel のみをシグナリングに利用する場合、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -156,6 +156,12 @@ data class ReOfferMessage(
     @SerializedName("sdp") val sdp: String
 )
 
+data class CloseMessage(
+    @SerializedName("type") val type: String = "close",
+    @SerializedName("code") val code: Int,
+    @SerializedName("reason") val reason: String,
+)
+
 data class ReAnswerMessage(
     @SerializedName("type") val type: String = "re-answer",
     @SerializedName("sdp") val sdp: String

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -196,6 +196,10 @@ class MessageConverter {
             return gson.fromJson(text, ReOfferMessage::class.java)
         }
 
+        fun parseCloseMessage(text: String): CloseMessage {
+            return gson.fromJson(text, CloseMessage::class.java)
+        }
+
         fun parseNotificationMessage(text: String): NotificationMessage {
             return gson.fromJson(text, NotificationMessage::class.java)
         }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraDisconnectReason.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraDisconnectReason.kt
@@ -7,6 +7,10 @@ enum class SoraDisconnectReason(val value: String?) {
     NO_ERROR("NO-ERROR"),
     WEBSOCKET_ONCLOSE("WEBSOCKET-ONCLOSE"),
     WEBSOCKET_ONERROR("WEBSOCKET-ONERROR"),
+    /**
+     * DataChannel シグナリングのみ利用時に Sora から切断が発生した
+     */
+    DATACHANNEL_ONCLOSE("DATACHANNEL-ONCLOSE"),
     PEER_CONNECTION_STATE_FAILED(null),
     SIGNALING_FAILURE(null),
 }


### PR DESCRIPTION
#161 で書いた CHANGES と関連するので、新規にセクションを追加するのではなく、その部分を更新しました。

---

- [UPDATE] `SoraMediaChannel.Listener` に Sora から切断されたときのステータスコードと理由を取得できる `onClose` を追加する
  - Sora から切断した時に通知されるイベントである `SoraCloseEvent` を追加した	  - Sora から切断されたときに通知されるイベントである `SoraCloseEvent` を追加した
  - WebSocket シグナリング切断時に通知されるイベントである `SignalingChannelCloseEvent` を追加した	  - WebSocket シグナリング切断時に通知されるイベントである `SignalingChannelCloseEvent` を追加した
  - 以下の場合に、Sora から切断された際に `SoraCloseEvent` が通知される:
    - WebSocket シグナリングを利用している場合
    - DataChannel のみをシグナリングに利用する場合、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合

---

This pull request includes several important changes to the `sora-android-sdk` to enhance the handling of DataChannel signaling and improve the clarity of disconnection events. The changes involve adding new event handling, updating existing methods, and introducing new data classes. Below are the most significant changes:

### Enhancements to DataChannel signaling:

* Added a new variable `dataChannelSignalingCloseEvent` to store the code and reason when a `type: close` message is received via DataChannel signaling (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`).
* Implemented the `handleSignalingViaDataChannel` method to process messages with the `signaling` label received via DataChannel, including handling `type: close` messages (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`).
* Added methods to handle `notify`, `push`, and `stats` labels received via DataChannel (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`).

### Handling of disconnection events:

* Updated the `onDataChannelClosed` method to use the `dataChannelSignalingCloseEvent` if available to provide detailed disconnection reasons (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`).
* Added a new disconnection reason `DATACHANNEL_ONCLOSE` to the `SoraDisconnectReason` enum to indicate disconnections specific to DataChannel signaling (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/error/SoraDisconnectReason.kt`).

### Data class and message parsing updates:

* Introduced a new data class `CloseMessage` to represent `type: close` messages, including code and reason fields (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt`).
* Added a `parseCloseMessage` method to the `MessageConverter` class to parse `CloseMessage` objects from JSON strings (`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt`).

### Documentation updates:

* Updated `CHANGES.md` to reflect the addition of `SoraCloseEvent` and the conditions under which it is notified (`CHANGES.md`).