### PR TITLE
ビデオコーデックにデフォルトで VP9 を設定するのをやめる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
   - 未設定時は、Sora 側でデフォルトのビデオコーデックが設定される。現時点では Sora が自動的に `VP9` を設定する
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
   - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
-  - @zztkmk
+  - @zztkm
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
   - 今回の変更により、未設定の場合は `video.codec_type` を送信しなくなった
   - 未設定時は、Sora 側でデフォルトのビデオコーデックが設定される。現時点では Sora が自動的に `VP9` を設定する
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
-  - connect メッセージで VP9 を明示的に設定する場合は、`SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
+  - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は今回の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
   - @zztkmk
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
   - 今回の変更により、未設定の場合は `video.codec_type` を送信しなくなった
   - 未設定時は、Sora 側でデフォルトのビデオコーデックが設定される。現時点では Sora が自動的に `VP9` を設定する
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
-  - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は今回の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
+  - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
   - @zztkmk
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,13 @@
   - これにより、`onError` はネットワーク切断などによる異常終了のみを通知する仕様になる
   - もし、ステータスコード 1000 以外の Sora からの切断を `onError` によって検知する実装を行っていた場合、今後は `onClose` のステータスコードを参照して適切な処理を行う必要がある
   - @zztkm 
+- [CHANGE] SoraMediaOption.videoCodec 未設定時の動作変更
+  - 以前は、`SoraMediaOption.videoCodec` が未設定の場合、connect メッセージの `video.codec_type` に自動で `VP9` が設定され送信されていた
+  - 今回の変更により、未設定の場合は `video.codec_type` を送信しなくなった
+  - 未設定時は、Sora 側でデフォルトのビデオコーデックが設定される。現時点では Sora が自動的に `VP9` を設定する
+    - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
+  - connect メッセージで VP9 を明示的に設定する場合は、`SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
+  - @zztkmk
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -45,8 +45,8 @@ class SoraMediaOption {
     /**
      * 映像コーデック.
      *
-     * 未設定の場合、 Sora Android SDK は DEFAULT を設定します.
-     * DEFAULT は Sora のデフォルト値を利用します.
+     * 未設定の場合 Sora Android SDK は DEFAULT を設定する.
+     * DEFAULT は Sora のデフォルト値を利用する.
      */
     var videoCodec = SoraVideoOption.Codec.DEFAULT
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -265,4 +265,15 @@ class SoraMediaOption {
      * Sora の音声ストリーミング機能利用時に指定する言語コード.
      */
     var audioStreamingLanguageCode: String? = null
+
+    /**
+     * シグナリング type: connect メッセージの video に含めるデータがすべてデフォルト値かどうか.
+     */
+    fun isDefaultVideoOption(): Boolean {
+        return videoCodec == SoraVideoOption.Codec.DEFAULT &&
+            videoBitrate == null &&
+            videoVp9Params == null &&
+            videoAv1Params == null &&
+            videoH264Params == null
+    }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -45,9 +45,10 @@ class SoraMediaOption {
     /**
      * 映像コーデック.
      *
-     * 未設定の場合、 Sora Android SDK は VP9 を設定します.
+     * 未設定の場合、 Sora Android SDK は DEFAULT を設定します.
+     * DEFAULT は Sora のデフォルト値を利用します.
      */
-    var videoCodec = SoraVideoOption.Codec.VP9
+    var videoCodec = SoraVideoOption.Codec.DEFAULT
 
     /**
      * 映像ビットレート.

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -13,14 +13,14 @@ class SoraVideoOption {
     enum class Codec {
         /** Sora のデフォルト値を利用 */
         DEFAULT,
-        /** H.264 */
-        H264,
-        /** H.265 */
-        H265,
         /** VP8 */
         VP8,
         /** VP9 */
         VP9,
+        /** H.264 */
+        H264,
+        /** H.265 */
+        H265,
         /** AV1 */
         AV1
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -11,6 +11,8 @@ class SoraVideoOption {
      * 利用できる映像コーデックを示します.
      */
     enum class Codec {
+        /** Sora のデフォルト値を利用 */
+        DEFAULT,
         /** H.264 */
         H264,
         /** H.265 */

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt
@@ -7,22 +7,23 @@ import android.graphics.Point
  */
 class SoraVideoOption {
 
+    // TODO(zztkm): 破壊的変更にはなるが、Codec の並び順を Sora のドキュメントに合わせて変更する
     /**
      * 利用できる映像コーデックを示します.
      */
     enum class Codec {
-        /** Sora のデフォルト値を利用 */
-        DEFAULT,
-        /** VP8 */
-        VP8,
-        /** VP9 */
-        VP9,
         /** H.264 */
         H264,
         /** H.265 */
         H265,
+        /** VP8 */
+        VP8,
+        /** VP9 */
+        VP9,
         /** AV1 */
-        AV1
+        AV1,
+        /** Sora のデフォルト値を利用 */
+        DEFAULT,
     }
 
     /**

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -62,7 +62,7 @@ data class ConnectMessage(
 )
 
 data class VideoSetting(
-    @SerializedName("codec_type") val codecType: String,
+    @SerializedName("codec_type") var codecType: String? = null,
     @SerializedName("bit_rate") var bitRate: Int? = null,
     @SerializedName("vp9_params") var vp9Params: Any? = null,
     @SerializedName("av1_params") var av1Params: Any? = null,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -80,18 +80,27 @@ class MessageConverter {
                     msg.audio = false
                 }
 
-                msg.video = if (mediaOption.videoUpstreamEnabled) {
-                    VideoSetting().apply {
-                        if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
-                            codecType = mediaOption.videoCodec.toString()
+                if (mediaOption.videoUpstreamEnabled) {
+                    val isDefault = mediaOption.videoCodec == SoraVideoOption.Codec.DEFAULT &&
+                        mediaOption.videoBitrate == null &&
+                        mediaOption.videoVp9Params == null &&
+                        mediaOption.videoAv1Params == null &&
+                        mediaOption.videoH264Params == null
+                    // video 関連設定がすべてデフォルト値の場合は video フィールドの設定を省略する
+                    if (!isDefault) {
+                        msg.video = VideoSetting().apply {
+                            if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
+                                codecType = mediaOption.videoCodec.toString()
+                            }
+                            mediaOption.videoBitrate?.let { bitRate = it }
+                            mediaOption.videoVp9Params?.let { vp9Params = it }
+                            mediaOption.videoAv1Params?.let { av1Params = it }
+                            mediaOption.videoH264Params?.let { h264Params = it }
                         }
-                        mediaOption.videoBitrate?.let { bitRate = it }
-                        mediaOption.videoVp9Params?.let { vp9Params = it }
-                        mediaOption.videoAv1Params?.let { av1Params = it }
-                        mediaOption.videoH264Params?.let { h264Params = it }
                     }
                 } else {
-                    false
+                    // ビデオを無効化したいため false を設定する
+                    msg.video = false
                 }
             } else {
                 // 視聴者では audio, video は視聴の設定

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -1,11 +1,13 @@
 package jp.shiguredo.sora.sdk.channel.signaling.message
 
+import android.provider.MediaStore.Video
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import jp.shiguredo.sora.sdk.channel.option.SoraChannelRole
 import jp.shiguredo.sora.sdk.channel.option.SoraForwardingFilterOption
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.error.SoraDisconnectReason
 import org.webrtc.RTCStats
 import org.webrtc.RTCStatsReport
@@ -78,15 +80,19 @@ class MessageConverter {
                 } else {
                     msg.audio = false
                 }
-                if (mediaOption.videoUpstreamEnabled) {
-                    val videoSetting = VideoSetting(mediaOption.videoCodec.toString())
-                    mediaOption.videoBitrate?.let { videoSetting.bitRate = it }
-                    mediaOption.videoVp9Params?.let { videoSetting.vp9Params = it }
-                    mediaOption.videoAv1Params?.let { videoSetting.av1Params = it }
-                    mediaOption.videoH264Params?.let { videoSetting.h264Params = it }
-                    msg.video = videoSetting
+
+                msg.video = if (mediaOption.videoUpstreamEnabled) {
+                    VideoSetting().apply {
+                        if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
+                            codecType = mediaOption.videoCodec.toString()
+                        }
+                        mediaOption.videoBitrate?.let { bitRate = it }
+                        mediaOption.videoVp9Params?.let { vp9Params = it }
+                        mediaOption.videoAv1Params?.let { av1Params = it }
+                        mediaOption.videoH264Params?.let { h264Params = it }
+                    }
                 } else {
-                    msg.video = false
+                    false
                 }
             } else {
                 // 視聴者では audio, video は視聴の設定
@@ -98,13 +104,18 @@ class MessageConverter {
                 } else {
                     msg.audio = false
                 }
-                if (mediaOption.videoDownstreamEnabled) {
-                    val videoSetting = VideoSetting(mediaOption.videoCodec.toString())
-                    // TODO(shino): 視聴側の bit_rate 設定はサーバで無視される
-                    mediaOption.videoBitrate?.let { videoSetting.bitRate = it }
-                    msg.video = videoSetting
+
+                msg.video = if (mediaOption.videoDownstreamEnabled) {
+                    VideoSetting().apply {
+                        if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
+                            codecType = mediaOption.videoCodec.toString()
+                        }
+                        // TODO(shino): 視聴側の bit_rate 設定はサーバで無視される
+                        // TODO(zztkm): ビデオコーデック以外は配信者が設定できる項目で、視聴者は設定不要なので、設定不要な項目は省略する
+                        mediaOption.videoBitrate?.let { bitRate = it }
+                    }
                 } else {
-                    msg.video = false
+                    false
                 }
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -1,6 +1,5 @@
 package jp.shiguredo.sora.sdk.channel.signaling.message
 
-import android.provider.MediaStore.Video
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -81,13 +81,8 @@ class MessageConverter {
                 }
 
                 if (mediaOption.videoUpstreamEnabled) {
-                    val isDefault = mediaOption.videoCodec == SoraVideoOption.Codec.DEFAULT &&
-                        mediaOption.videoBitrate == null &&
-                        mediaOption.videoVp9Params == null &&
-                        mediaOption.videoAv1Params == null &&
-                        mediaOption.videoH264Params == null
                     // video 関連設定がすべてデフォルト値の場合は video フィールドの設定を省略する
-                    if (!isDefault) {
+                    if (!mediaOption.isDefaultVideoOption()) {
                         msg.video = VideoSetting().apply {
                             if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
                                 codecType = mediaOption.videoCodec.toString()
@@ -113,17 +108,20 @@ class MessageConverter {
                     msg.audio = false
                 }
 
-                msg.video = if (mediaOption.videoDownstreamEnabled) {
-                    VideoSetting().apply {
-                        if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
-                            codecType = mediaOption.videoCodec.toString()
+                if (mediaOption.videoDownstreamEnabled) {
+                    // video 関連設定がすべてデフォルト値の場合は video フィールドの設定を省略する
+                    if (!mediaOption.isDefaultVideoOption()) {
+                        msg.video = VideoSetting().apply {
+                            if (mediaOption.videoCodec != SoraVideoOption.Codec.DEFAULT) {
+                                codecType = mediaOption.videoCodec.toString()
+                            }
+                            // TODO(shino): 視聴側の bit_rate 設定はサーバで無視される
+                            // TODO(zztkm): ビデオコーデック以外は配信者が設定できる項目で、視聴者は設定不要なので、設定不要な項目は省略する
+                            mediaOption.videoBitrate?.let { bitRate = it }
                         }
-                        // TODO(shino): 視聴側の bit_rate 設定はサーバで無視される
-                        // TODO(zztkm): ビデオコーデック以外は配信者が設定できる項目で、視聴者は設定不要なので、設定不要な項目は省略する
-                        mediaOption.videoBitrate?.let { bitRate = it }
                     }
                 } else {
-                    false
+                    msg.video = false
                 }
             }
 


### PR DESCRIPTION
- [CHANGE] SoraMediaOption.videoCodec 未設定時の動作変更
  - 以前は、`SoraMediaOption.videoCodec` が未設定の場合、connect メッセージの `video.codec_type` に自動で `VP9` が設定され送信されていた
  - 今回の変更により、未設定の場合は `video.codec_type` を送信しなくなった
  - 未設定時は、Sora 側でデフォルトのビデオコーデックが設定される。現時点では Sora が自動的に `VP9` を設定する
    - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
  - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある

---

This pull request introduces several changes to the `sora-android-sdk` to modify the behavior of the `SoraMediaOption.videoCodec` when it is unset. The primary change is that the SDK will now use the default value set by Sora instead of automatically setting it to `VP9`. Additionally, the pull request includes updates to the `MessageConverter` to omit the `video` field when all video-related settings are at their default values.

Changes to `SoraMediaOption`:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt`](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427L48-R51): Modified the `videoCodec` to use `DEFAULT` instead of `VP9` when unset, and added the `isDefaultVideoOption` method to check if all video settings are at their default values. [[1]](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427L48-R51) [[2]](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427R268-R278)

Changes to `SoraVideoOption`:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraVideoOption.kt`](diffhunk://#diff-a8e5b3fadafde5846cdcd1b8e0c878dc88321658dac1c45b8d2fc01c070e7a06L14-R23): Added a `DEFAULT` enum value to represent the default codec value used by Sora.

Changes to `MessageConverter`:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt`](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR82-R97): Updated the `MessageConverter` to omit the `video` field in the connect message if all video-related settings are at their default values. [[1]](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR82-R97) [[2]](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cR110-R122)

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R25-R31): Updated the documentation to reflect the new behavior of `SoraMediaOption.videoCodec` and the implications of this change.

These changes ensure that the SDK aligns with the default behavior of Sora, simplifying the configuration for users who do not need to specify custom video codec settings.