### PR TITLE
type: connect 送信時にデフォルトで audio codec_type を OPUS にするのをやめる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
   - 未設定時は、Sora 側でデフォルトのオーディオコーデックが設定される。現時点では Sora が自動的に `OPUS` を設定する
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#0fcf4e
   - `SoraMediaOption.audioCodec` が未設定、かつ `SoraMediaOption.audioOption.opusParams` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.audioCodec` に `SoraAudioOption.Codec.OPUS` を設定する必要がある
+  - @zztkm
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,12 @@
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#d47f4d
   - `SoraMediaOption.videoCodec` が未設定、かつ `SoraMediaOption.videoVp9Params` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.videoCodec` に `SoraVideoOption.Codec.VP9` を設定する必要がある
   - @zztkm
+- [CHANGE] SoraMediaOption.audioCodec 未設定時の動作変更
+  - 以前は、`SoraMediaOption.audioCodec` が未設定の場合、connect メッセージの `audio.codec_type` に自動で `OPUS` が設定され送信されていた
+  - 今回の変更により、未設定の場合は `audio.codec_type` を送信しなくなった
+  - 未設定時は、Sora 側でデフォルトのオーディオコーデックが設定される。現時点では Sora が自動的に `OPUS` を設定する
+    - 参考: https://sora-doc.shiguredo.jp/SIGNALING#0fcf4e
+  - `SoraMediaOption.audioCodec` が未設定、かつ `SoraMediaOption.audioOption.opusParams` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.audioCodec` に `SoraAudioOption.Codec.OPUS` を設定する必要がある
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
@@ -16,12 +16,16 @@ class SoraAudioOption {
         const val HIGH_PASS_FILTER_CONSTRAINT = "googHighpassFilter"
         const val NOISE_SUPPRESSION_CONSTRAINT = "googNoiseSuppression"
     }
+
+    // TODO(zztkm): 破壊的変更にはなるが、DEFAULT を先頭に持ってくる
     /**
      * 利用できる音声コーデックを示します.
      */
     enum class Codec {
         /** Opus */
         OPUS,
+        /** Sora のデフォルト値を利用 */
+        DEFAULT,
     }
 
     /**

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -155,8 +155,11 @@ class SoraMediaOption {
 
     /**
      * 音声コーデック.
+     *
+     * 未設定の場合 Sora Android SDK は DEFAULT を設定する.
+     * DEFAULT は Sora のデフォルト値を利用する.
      */
-    var audioCodec = SoraAudioOption.Codec.OPUS
+    var audioCodec = SoraAudioOption.Codec.DEFAULT
 
     // audioBitRate が正しい綴りだが後方互換性を壊すほどではないので放置する
     /**
@@ -269,11 +272,20 @@ class SoraMediaOption {
     /**
      * シグナリング type: connect メッセージの video に含めるデータがすべてデフォルト値かどうか.
      */
-    fun isDefaultVideoOption(): Boolean {
+    internal fun isDefaultVideoOption(): Boolean {
         return videoCodec == SoraVideoOption.Codec.DEFAULT &&
             videoBitrate == null &&
             videoVp9Params == null &&
             videoAv1Params == null &&
             videoH264Params == null
+    }
+
+    /**
+     * シグナリング type: connect メッセージの audio に含めるデータがすべてデフォルト値かどうか.
+     */
+    internal fun isDefaultAudioOption(): Boolean {
+        return audioCodec == SoraAudioOption.Codec.DEFAULT &&
+            audioBitrate == null &&
+            audioOption.opusParams == null
     }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/Catalog.kt
@@ -70,7 +70,7 @@ data class VideoSetting(
 )
 
 data class AudioSetting(
-    @SerializedName("codec_type") val codecType: String?,
+    @SerializedName("codec_type") var codecType: String? = null,
     @SerializedName("bit_rate") var bitRate: Int? = null,
     @SerializedName("opus_params") var opusParams: OpusParams? = null
 )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt
@@ -3,6 +3,7 @@ package jp.shiguredo.sora.sdk.channel.signaling.message
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
+import jp.shiguredo.sora.sdk.channel.option.SoraAudioOption
 import jp.shiguredo.sora.sdk.channel.option.SoraChannelRole
 import jp.shiguredo.sora.sdk.channel.option.SoraForwardingFilterOption
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
@@ -68,14 +69,15 @@ class MessageConverter {
             if (mediaOption.upstreamIsRequired) {
                 // 配信者では audio, video は配信の設定
                 if (mediaOption.audioUpstreamEnabled) {
-                    val audioSetting = AudioSetting(mediaOption.audioCodec.toString())
-                    mediaOption.audioBitrate?.let { audioSetting.bitRate = it }
-
-                    if (mediaOption.audioOption.opusParams != null) {
-                        audioSetting.opusParams = mediaOption.audioOption.opusParams
+                    if (!mediaOption.isDefaultAudioOption()) {
+                        msg.audio = AudioSetting().apply {
+                            if (mediaOption.audioCodec != SoraAudioOption.Codec.DEFAULT) {
+                                codecType = mediaOption.audioCodec.toString()
+                            }
+                            mediaOption.audioBitrate?.let { bitRate = it }
+                            mediaOption.audioOption.opusParams?.let { opusParams = it }
+                        }
                     }
-
-                    msg.audio = audioSetting
                 } else {
                     msg.audio = false
                 }


### PR DESCRIPTION
- [CHANGE] SoraMediaOption.audioCodec 未設定時の動作変更
  - 以前は、`SoraMediaOption.audioCodec` が未設定の場合、connect メッセージの `audio.codec_type` に自動で `OPUS` が設定され送信されていた
  - 今回の変更により、未設定の場合は `audio.codec_type` を送信しなくなった
  - 未設定時は、Sora 側でデフォルトのオーディオコーデックが設定される。現時点では Sora が自動的に `OPUS` を設定する
    - 参考: https://sora-doc.shiguredo.jp/SIGNALING#0fcf4e
  - `SoraMediaOption.audioCodec` が未設定、かつ `SoraMediaOption.audioOption.opusParams` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.audioCodec` に `SoraAudioOption.Codec.OPUS` を設定する必要がある

---

This pull request includes several changes to the `SoraMediaOption` and related classes to modify the handling of audio codec settings and improve the overall functionality. The most important changes include updating the default audio codec behavior, adding new methods to check default options, and making some internal adjustments to the codebase.

### Changes to audio codec handling:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R32-R38): Updated to reflect the change in behavior when `SoraMediaOption.audioCodec` is unset. Now, the `audio.codec_type` is not sent if unset, and Sora will use its default codec, currently `OPUS`.
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt`](diffhunk://#diff-d1f255abbbbc4a50eb6ed6bd4fd496e122641f97019d5b201289956270719cfeR19-R28): Added a new `DEFAULT` value to the `Codec` enum to represent Sora's default audio codec.
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt`](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427R158-R162): Changed the default value of `audioCodec` to `SoraAudioOption.Codec.DEFAULT` instead of `SoraAudioOption.Codec.OPUS`.

### Internal improvements:

* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt`](diffhunk://#diff-d9defc53e2f218f5a3d94940d73b3b2152b3209c46ed799eae32d6a0cd0a2427L272-R290): Added a new internal method `isDefaultAudioOption` to check if all audio options are set to their default values.
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/message/MessageConverter.kt`](diffhunk://#diff-67e9bf1bcfe0fde028ed5988fef4e2c0f2aab95a5f98de108f1388058815fc3cL71-L78): Updated the logic to only include audio settings in the connect message if they are not set to default values.

These changes improve the flexibility and clarity of how audio codecs are handled in the Sora Android SDK, ensuring that default values are used appropriately and only necessary settings are sent in signaling messages.