### PR TITLE
onError コールバックの統一のために onError(mediaChannel, reason) を deprecated に変更し、`onError(SoraMediaChannel, SoraErrorReason, String)` も呼び出すようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,9 @@
     - WebSocket 経由のシグナリングを利用している場合
     - DataChannel 経由のシグナリングを利用する場合、かつ `ignore_disconnect_websocket` が true、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
   - @zztkm
+- [UPDATE] SoraMediaChannel.Listener の `onError(SoraMediaChannel, SoraErrorReason)` を非推奨にする
+  - `onError(SoraMediaChannel, SoraErrorReason)` は `onError(SoraMediaChannel, SoraErrorReason, String)` に置き換えられる
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -720,7 +720,7 @@ class SoraMediaChannel @JvmOverloads constructor(
 
     private fun onTimeout() {
         SoraLogger.d(TAG, "[channel:$role] @peer:onTimeout")
-        listener?.onError(this, SoraErrorReason.TIMEOUT )
+        listener?.onError(this, SoraErrorReason.TIMEOUT)
         listener?.onError(this, SoraErrorReason.TIMEOUT, "")
 
         // ここに来た場合、 Sora に接続出来ていない = disconnect メッセージを送信する必要がない

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -248,10 +248,16 @@ class SoraMediaChannel @JvmOverloads constructor(
          *
          * @param reason エラーの理由
          */
+        @Deprecated(
+            "エラー発生時のコールバックは onError(mediaChannel, reason, message) に集約するため、このメソッドは非推奨です",
+            ReplaceWith("onError(mediaChannel, reason, message)"),
+            DeprecationLevel.WARNING
+        )
         fun onError(mediaChannel: SoraMediaChannel, reason: SoraErrorReason) {}
 
         /**
          * Sora との通信やメディアでエラーが発生したときに呼び出されるコールバック.
+         * message の内容がない場合は、空文字列が渡されます.
          *
          * cf.
          * - `org.webrtc.PeerConnection`
@@ -479,6 +485,7 @@ class SoraMediaChannel @JvmOverloads constructor(
                 SoraLogger.d(TAG, "[channel:$role] @signaling:onError: IGNORE reason=$reason")
             } else {
                 listener?.onError(this@SoraMediaChannel, reason)
+                listener?.onError(this@SoraMediaChannel, reason, "")
             }
         }
 
@@ -597,6 +604,7 @@ class SoraMediaChannel @JvmOverloads constructor(
         override fun onError(reason: SoraErrorReason) {
             SoraLogger.d(TAG, "[channel:$role] @peer:onError:$reason")
             listener?.onError(this@SoraMediaChannel, reason)
+            listener?.onError(this@SoraMediaChannel, reason, "")
         }
 
         override fun onError(reason: SoraErrorReason, message: String) {
@@ -712,7 +720,8 @@ class SoraMediaChannel @JvmOverloads constructor(
 
     private fun onTimeout() {
         SoraLogger.d(TAG, "[channel:$role] @peer:onTimeout")
-        listener?.onError(this, SoraErrorReason.TIMEOUT)
+        listener?.onError(this, SoraErrorReason.TIMEOUT )
+        listener?.onError(this, SoraErrorReason.TIMEOUT, "")
 
         // ここに来た場合、 Sora に接続出来ていない = disconnect メッセージを送信する必要がない
         // そのため、 reason は null で良い


### PR DESCRIPTION
- [UPDATE] SoraMediaChannel.Listener の `onError(SoraMediaChannel, SoraErrorReason)` を非推奨にする
  - `onError(SoraMediaChannel, SoraErrorReason)` は `onError(SoraMediaChannel, SoraErrorReason, String)` に置き換えられる
