### PR TITLE
`onError(SoraMediaChannel, SoraErrorReason)` を廃止する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,11 @@
     - 参考: https://sora-doc.shiguredo.jp/SIGNALING#0fcf4e
   - `SoraMediaOption.audioCodec` が未設定、かつ `SoraMediaOption.audioOption.opusParams` を設定している場合は破壊的変更の影響を受けるため、明示的に `SoraMediaOption.audioCodec` に `SoraAudioOption.Codec.OPUS` を設定する必要がある
   - @zztkm
+- [CHANGE] SoraMediaChannel.Listener の `onError(SoraMediaChannel, SoraErrorReason)` を廃止する
+  - `onError(SoraMediaChannel, SoraErrorReason)` を呼び出していた箇所は `onError(SoraMediaChannel, SoraErrorReason, String)` に置き換えられる
+  - String にはエラーの詳細情報を設定する
+    - 詳細がない場合は空文字列を設定する
+  - @zztkm
 - [UPDATE] libwebrtc を 132.6834.5.3 に上げる
   - @zztkm
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする
@@ -59,9 +64,6 @@
   - 以下の場合に、Sora から切断された際に `SoraCloseEvent` が通知される:
     - WebSocket 経由のシグナリングを利用している場合
     - DataChannel 経由のシグナリングを利用する場合、かつ `ignore_disconnect_websocket` が true、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
-  - @zztkm
-- [UPDATE] SoraMediaChannel.Listener の `onError(SoraMediaChannel, SoraErrorReason)` を非推奨にする
-  - `onError(SoraMediaChannel, SoraErrorReason)` は `onError(SoraMediaChannel, SoraErrorReason, String)` に置き換えられる
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -240,23 +240,6 @@ class SoraMediaChannel @JvmOverloads constructor(
 
         /**
          * Sora との通信やメディアでエラーが発生したときに呼び出されるコールバック.
-         *
-         * cf.
-         * - `org.webrtc.PeerConnection`
-         * - `org.webrtc.PeerConnection.Observer`
-         * - [PeerChannel]
-         *
-         * @param reason エラーの理由
-         */
-        @Deprecated(
-            "エラー発生時のコールバックは onError(mediaChannel, reason, message) に集約するため、このメソッドは非推奨です",
-            ReplaceWith("onError(mediaChannel, reason, message)"),
-            DeprecationLevel.WARNING
-        )
-        fun onError(mediaChannel: SoraMediaChannel, reason: SoraErrorReason) {}
-
-        /**
-         * Sora との通信やメディアでエラーが発生したときに呼び出されるコールバック.
          * message の内容がない場合は、空文字列が渡されます.
          *
          * cf.
@@ -484,7 +467,6 @@ class SoraMediaChannel @JvmOverloads constructor(
                 // なにもしない
                 SoraLogger.d(TAG, "[channel:$role] @signaling:onError: IGNORE reason=$reason")
             } else {
-                listener?.onError(this@SoraMediaChannel, reason)
                 listener?.onError(this@SoraMediaChannel, reason, "")
             }
         }
@@ -603,7 +585,6 @@ class SoraMediaChannel @JvmOverloads constructor(
 
         override fun onError(reason: SoraErrorReason) {
             SoraLogger.d(TAG, "[channel:$role] @peer:onError:$reason")
-            listener?.onError(this@SoraMediaChannel, reason)
             listener?.onError(this@SoraMediaChannel, reason, "")
         }
 
@@ -720,7 +701,6 @@ class SoraMediaChannel @JvmOverloads constructor(
 
     private fun onTimeout() {
         SoraLogger.d(TAG, "[channel:$role] @peer:onTimeout")
-        listener?.onError(this, SoraErrorReason.TIMEOUT)
         listener?.onError(this, SoraErrorReason.TIMEOUT, "")
 
         // ここに来た場合、 Sora に接続出来ていない = disconnect メッセージを送信する必要がない


### PR DESCRIPTION
#169 の対応方針を変更し、onError の破壊的変更を入れるようにしました。

- [CHANGE] SoraMediaChannel.Listener の `onError(SoraMediaChannel, SoraErrorReason)` を廃止する
  - `onError(SoraMediaChannel, SoraErrorReason)` を呼び出していた箇所は `onError(SoraMediaChannel, SoraErrorReason, String)` に置き換えられる
  - String にはエラーの詳細情報を設定する
    - 詳細がない場合は空文字列を設定する

---

This pull request includes changes to the `SoraMediaChannel` class and its associated listener interface to deprecate and replace the `onError(SoraMediaChannel, SoraErrorReason)` method with a new method that includes an additional `String` parameter for error details. The most important changes are summarized below:

Deprecation and Replacement of `onError` Method:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R39-R43): Deprecated `onError(SoraMediaChannel, SoraErrorReason)` and replaced it with `onError(SoraMediaChannel, SoraErrorReason, String)`. The new method includes a `String` parameter for error details, which is set to an empty string if no details are available. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R39-R43) [[2]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L63-L65)
* [`sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt`](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L241-L257): Removed the deprecated `onError(SoraMediaChannel, SoraErrorReason)` method from the `SoraMediaChannel.Listener` interface. Updated all calls to this method to use the new `onError(SoraMediaChannel, SoraErrorReason, String)` method with an empty string as the default error message. [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L241-L257) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L487) [[3]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L606) [[4]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416L723)