### PR TITLE
WSS 接続に利用する CA 証明書を設定可能にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,11 @@
 - [UPDATE] `SoraMediaChannel.Listener` の `onClose(SoraMediaChannel)` を非推奨に変更する
   - 今後は `onClose(SoraMediaChannel, SoraCloseEvent?)` を利用してもらう
   - @zztkm
+- [UPDATE] シグナリング接続時に CA 証明書を指定できるようにする
+  - `SoraMediaChannel` に `caCertificate: Certificate` を追加する
+    - TODO(zztkm): X509Certificate と Certificate のどちらが良いか確認する
+  - `SoraMediaChannel` で CA 証明書を指定しない場合はシステムのデフォルトが利用される
+  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [FIX] `SoraMediaChannel.internalDisconnect` での `SoraMediaChannel.Listener.onClose` の呼び出しタイミングを切断処理がすべて完了したあとに修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,9 +69,8 @@
   - 今後は `onClose(SoraMediaChannel, SoraCloseEvent?)` を利用してもらう
   - @zztkm
 - [UPDATE] シグナリング接続時に CA 証明書を指定できるようにする
-  - `SoraMediaChannel` に `caCertificate: Certificate` を追加する
-    - TODO(zztkm): X509Certificate と Certificate のどちらが良いか確認する
-  - `SoraMediaChannel` で CA 証明書を指定しない場合はシステムのデフォルトが利用される
+  - `SoraMediaChannel` に `caCertificate: Certificate?` を追加する
+  - `SoraMediaChannel` で CA 証明書を指定しない場合は、サーバー証明書の検証にシステムのデフォルトが利用される
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -38,6 +38,7 @@ import org.webrtc.SessionDescription
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
+import java.security.cert.Certificate
 import java.util.Timer
 import java.util.TimerTask
 import kotlin.concurrent.schedule
@@ -95,6 +96,10 @@ class SoraMediaChannel @JvmOverloads constructor(
     )
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
     private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
+    // 参考 URL
+    // - https://developer.android.com/reference/kotlin/java/security/cert/Certificate
+    // - https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate
+    private val caCertificate: Certificate? = null,
 ) {
     companion object {
         private val TAG = SoraMediaChannel::class.simpleName
@@ -785,7 +790,8 @@ class SoraMediaChannel @JvmOverloads constructor(
             connectDataChannels = connectDataChannels,
             redirect = redirectLocation != null,
             forwardingFilterOption = forwardingFilterOption,
-            forwardingFiltersOption = forwardingFiltersOption
+            forwardingFiltersOption = forwardingFiltersOption,
+            caCertificate = caCertificate,
         )
         signaling!!.connect()
     }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -72,6 +72,7 @@ import kotlin.concurrent.schedule
  * @param bundleId connect メッセージに含める `bundle_id`
  * @param forwardingFilterOption 転送フィルター機能の設定
  * @param forwardingFiltersOption リスト形式の転送フィルター機能の設定
+ * @param caCertificate Sora との接続に利用する CA 証明書
  */
 class SoraMediaChannel @JvmOverloads constructor(
     private val context: Context,
@@ -96,7 +97,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     )
     private val forwardingFilterOption: SoraForwardingFilterOption? = null,
     private val forwardingFiltersOption: List<SoraForwardingFilterOption>? = null,
-    // 参考 URL
+    // Certificate についての参考 URL
     // - https://developer.android.com/reference/kotlin/java/security/cert/Certificate
     // - https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate
     private val caCertificate: Certificate? = null,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -112,12 +112,16 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 trustManagerFactory.init(keyStore) // カスタムキーストアで初期化
 
                 val trustManagers = trustManagerFactory.trustManagers
-                if (trustManagers.size != 1 || trustManagers[0] !is X509TrustManager) {
+                val x509TrustManagers = trustManagers.filterIsInstance<X509TrustManager>()
+                if (x509TrustManagers.isEmpty()) {
                     // 予期しない TrustManager が返された場合はログを出力し、カスタムの SSLSocketFactory を使用しない
-                    SoraLogger.w(TAG, "Unexpected default trust managers: ${trustManagers.contentToString()}")
-                    SoraLogger.w(TAG, "Falling back to default SSL context due to unexpected trust managers.")
+                    SoraLogger.w(TAG, "No X509TrustManager found in trust managers: ${trustManagers.contentToString()}")
+                    SoraLogger.w(TAG, "Falling back to default SSL context due to missing X509TrustManager.")
                 } else {
-                    val trustManager = trustManagers[0] as X509TrustManager
+                    if (x509TrustManagers.size > 1) {
+                        SoraLogger.w(TAG, "Multiple X509TrustManagers found. Using the first one.")
+                    }
+                    val trustManager = x509TrustManagers[0]
 
                     // カスタムTrustManagerを使用するSSLContextを作成
                     val sslContext = SSLContext.getInstance("TLS")


### PR DESCRIPTION
- [UPDATE] シグナリング接続時に CA 証明書を指定できるようにする
  - `SoraMediaChannel` に `caCertificate: Certificate?` を追加する
  - `SoraMediaChannel` で CA 証明書を指定しない場合は、サーバー証明書の検証にシステムのデフォルトが利用される

---

This pull request introduces a new feature allowing the specification of a custom CA certificate for signaling connections in the `SoraMediaChannel` class. It also includes updates to the `SignalingChannel` implementation to support this feature. Below is a summary of the most important changes:

### New Feature: Custom CA Certificate Support

* **Added CA certificate parameter to `SoraMediaChannel` and `SignalingChannel` constructors**: A new optional parameter, `caCertificate` of type `Certificate?`, has been added to allow users to specify a custom CA certificate for secure signaling connections. [[1]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R75) [[2]](diffhunk://#diff-eca9c509b83b3bd6b7b862d677f21883d7ccdbb48d803e4af5085fb1171b7416R100-R103) [[3]](diffhunk://#diff-c529544a54ce51de69bad096d484e622b2c8cd58a4e1b01320924133d03b8ac8R84)
* **Implemented custom SSL context for `SignalingChannel`**: When a `caCertificate` is provided, a custom `KeyStore` and `TrustManager` are created to initialize an `SSLContext` for secure connections. This ensures the custom certificate is used for server certificate validation.

### Documentation and Code Annotations

* **Updated `CHANGES.md`**: Documented the addition of the `caCertificate` parameter and its behavior when specified or left null.
* **Added reference links in code comments**: Included links to relevant Android documentation for `Certificate` and `X509Certificate` to help developers understand the new parameter.

These changes enhance the flexibility and security of the `SoraMediaChannel` by allowing developers to use custom CA certificates for signaling connections.