### PR TITLE
TURN-TLS の CA Cert 指定機能を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,10 @@
 - [UPDATE] `SoraMediaChannel.Listener` の `onClose(SoraMediaChannel)` を非推奨に変更する
   - 今後は `onClose(SoraMediaChannel, SoraCloseEvent?)` を利用してもらう
   - @zztkm
-- [UPDATE] シグナリング接続時に CA 証明書を指定できるようにする
+- [UPDATE] CA 証明書を指定できるようにする
+  - この証明書は以下のタイミングで利用される
+    - シグナリング接続時
+    - TURN-TLS 利用時
   - `SoraMediaChannel` に `caCertificate: Certificate?` を追加する
   - `SoraMediaChannel` で CA 証明書を指定しない場合は、サーバー証明書の検証にシステムのデフォルトが利用される
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,9 @@
     - WebSocket シグナリング利用時
     - TURN-TLS 利用時
   - `SoraMediaChannel` に `caCertificate: X509Certificate?` を追加する
-  - `SoraMediaChannel` で CA 証明書を指定しない場合は、サーバー証明書の検証にシステムのデフォルトが利用される
+  - `SoraMediaChannel` で CA 証明書を指定しない場合のデフォルトの動作は以下
+    - WebSocket シグナリングは OkHttp によりシステムのデフォルトが利用される
+    - TURN-TLS は libwebrtc に内蔵されている証明書が利用される
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -736,7 +736,8 @@ class SoraMediaChannel @JvmOverloads constructor(
                 mediaOption = mediaOption
             ),
             mediaOption = mediaOption,
-            listener = null
+            listener = null,
+            caCertificate = caCertificate,
         )
         clientOfferPeer.run {
             val subscription = requestClientOfferSdp()
@@ -810,7 +811,8 @@ class SoraMediaChannel @JvmOverloads constructor(
             mediaOption = mediaOption,
             simulcastEnabled = offerMessage.simulcast,
             dataChannelConfigs = offerMessage.dataChannels,
-            listener = peerListener
+            listener = peerListener,
+            caCertificate = caCertificate,
         )
 
         if (offerMessage.dataChannels?.isNotEmpty() == true) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -27,20 +27,14 @@ import org.webrtc.RtpParameters
 import org.webrtc.RtpReceiver
 import org.webrtc.RtpSender
 import org.webrtc.RtpTransceiver
-import org.webrtc.SSLCertificateVerifier
 import org.webrtc.SdpObserver
 import org.webrtc.SessionDescription
 import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
-import java.security.KeyStore
-import java.security.cert.Certificate
-import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.zip.DeflaterInputStream
-import javax.net.ssl.TrustManagerFactory
-import javax.net.ssl.X509TrustManager
 
 interface PeerChannel {
     fun handleInitialRemoteOffer(

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -483,7 +483,7 @@ class PeerChannelImpl(
         if (caCertificate != null) {
             try {
                 dependenciesBuilder.setSSLCertificateVerifier(CustomSSLCertificateVerifier(caCertificate))
-            } catch (e : Exception) {
+            } catch (e: Exception) {
                 // CustomSSLCertificateVerifier の初期化に失敗した場合はログを出力して
                 // カスタムのサーバー証明書検証処理を設定しない
                 SoraLogger.w(TAG, "skip setting CustomSSLCertificateVerifier: $e")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -99,6 +99,8 @@ class CustomSSLCertificateVerifier(
         buildTrustManager(caCertificate)
 
     override fun verify(cert: ByteArray?): Boolean {
+        // TODO(zztkm): caCertificate がユーザー指定されていない場合は、OS の CA 証明書を使うように実装する
+        // 例 LetsEncrypt の証明書を検証する場合など
         if (cert == null) {
             SoraLogger.w("CustomSSLCertificateVerifier", "cert is null")
             return false

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -472,7 +472,6 @@ class PeerChannelImpl(
 
         SoraLogger.d(TAG, "createPeerConnection")
         val dependenciesBuilder = PeerConnectionDependencies.builder(connectionObserver)
-        // TODO(zztkm): CA Cert が指定された場合のみ
 
         if (caCertificate != null) {
             try {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -26,6 +26,7 @@ import org.webrtc.RtpParameters
 import org.webrtc.RtpReceiver
 import org.webrtc.RtpSender
 import org.webrtc.RtpTransceiver
+import org.webrtc.SSLCertificateVerifier
 import org.webrtc.SdpObserver
 import org.webrtc.SessionDescription
 import java.io.ByteArrayInputStream
@@ -72,6 +73,14 @@ interface PeerChannel {
         fun onError(reason: SoraErrorReason, message: String)
         fun onWarning(reason: SoraErrorReason)
         fun onWarning(reason: SoraErrorReason, message: String)
+    }
+}
+
+class CustomSSLCertificateVerifier : SSLCertificateVerifier {
+    override fun verify(cert: ByteArray?): Boolean {
+        // TODO(zztkm): SSL 証明書の検証を行う
+        SoraLogger.d("CustomSSLCertificateVerifier", "verify")
+        return true
     }
 }
 
@@ -469,6 +478,8 @@ class PeerChannelImpl(
 
         SoraLogger.d(TAG, "createPeerConnection")
         val dependenciesBuilder = PeerConnectionDependencies.builder(connectionObserver)
+        // TODO(zztkm): CA Cert が指定された場合のみ
+        dependenciesBuilder.setSSLCertificateVerifier(CustomSSLCertificateVerifier())
         if (mediaOption.proxy.type != ProxyType.NONE) {
             dependenciesBuilder.setProxy(
                 mediaOption.proxy.type,

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
@@ -1,0 +1,57 @@
+package jp.shiguredo.sora.sdk.tls
+
+import jp.shiguredo.sora.sdk.util.SoraLogger
+import org.webrtc.SSLCertificateVerifier
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+/**
+ * TURN-TLS のサーバ証明書を、指定した CA 証明書で検証する Verifier。
+ *
+ * @param caCertificate   X.509 形式 (PEM / DER どちらでも可) の CA 証明書
+ *
+ * @throws NoSuchElementException 初期化時に X509TrustManager が取得できなかった場合
+ */
+class CustomSSLCertificateVerifier(
+    private val caCertificate: X509Certificate
+) : SSLCertificateVerifier {
+
+    /**
+     * コンストラクタ実行時に TrustManager を生成して保持しておく。
+     *
+     * CustomSSLCertificateVerifier の build は例外をスローする可能性があるため、
+     * CustomSSLCertificateVerifier のインスタンスを生成する際に、例外処理を行う。
+     */
+    private val trustManager: X509TrustManager =
+        CustomX509TrustManagerBuilder(caCertificate).build()
+
+    override fun verify(cert: ByteArray?): Boolean {
+        // TODO(zztkm): caCertificate がユーザー指定されていない場合は、OS の CA 証明書を使うように実装する
+        // 例 LetsEncrypt の証明書を検証する場合など
+        if (cert == null) {
+            SoraLogger.w("CustomSSLCertificateVerifier", "cert is null")
+            return false
+        }
+
+        return try {
+            // DER → X509Certificate に変換
+            val serverCert = CertificateFactory.getInstance("X.509")
+                .generateCertificate(ByteArrayInputStream(cert)) as X509Certificate
+
+            // 有効期限チェック
+            serverCert.checkValidity()
+
+            // チェーン検証
+            trustManager.checkServerTrusted(
+                arrayOf(serverCert),
+                serverCert.publicKey.algorithm
+            )
+            true
+        } catch (e: Exception) {
+            // 例外＝検証失敗
+            false
+        }
+    }
+}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
@@ -18,6 +18,10 @@ class CustomSSLCertificateVerifier(
     private val caCertificate: X509Certificate
 ) : SSLCertificateVerifier {
 
+    companion object {
+        private val TAG = CustomSSLCertificateVerifier::class.simpleName
+    }
+
     /**
      * コンストラクタ実行時に TrustManager を生成して保持しておく。
      *
@@ -31,7 +35,7 @@ class CustomSSLCertificateVerifier(
         // TODO(zztkm): caCertificate がユーザー指定されていない場合は、OS の CA 証明書を使うように実装する
         // 例 LetsEncrypt の証明書を検証する場合など
         if (cert == null) {
-            SoraLogger.w("CustomSSLCertificateVerifier", "cert is null")
+            SoraLogger.w(TAG, "verify return false. because cert is null")
             return false
         }
 
@@ -51,6 +55,7 @@ class CustomSSLCertificateVerifier(
             true
         } catch (e: Exception) {
             // 例外＝検証失敗
+            SoraLogger.e(TAG, "verify return false. because certificate is invalid", e)
             false
         }
     }


### PR DESCRIPTION
CA 証明書の指定機能自体は #173 で対応していましたが、TURN-TLS のサーバー証明書検証にも利用するようにしました。