### PR TITLE
X509TrustManager を生成する処理を別 class に分離

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -10,6 +10,7 @@ import jp.shiguredo.sora.sdk.channel.signaling.message.PushMessage
 import jp.shiguredo.sora.sdk.channel.signaling.message.SwitchedMessage
 import jp.shiguredo.sora.sdk.error.SoraDisconnectReason
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
+import jp.shiguredo.sora.sdk.tls.CustomX509TrustManagerBuilder
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -25,14 +26,11 @@ import org.webrtc.RTCStatsReport
 import org.webrtc.SessionDescription
 import java.net.InetSocketAddress
 import java.net.Proxy
-import java.security.KeyStore
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManagerFactory
-import javax.net.ssl.X509TrustManager
 
 interface SignalingChannel {
 
@@ -99,34 +97,17 @@ class SignalingChannelImpl @JvmOverloads constructor(
             var builder = OkHttpClient.Builder().readTimeout(0, TimeUnit.MILLISECONDS)
 
             if (caCertificate != null) {
-                SoraLogger.i(TAG, "set caCertificate")
-                // CA証明書を含むキーストアを作成
-                val keyStoreType = KeyStore.getDefaultType()
-                val keyStore = KeyStore.getInstance(keyStoreType)
-                keyStore.load(null, null) // 空のキーストアを初期化
-                keyStore.setCertificateEntry("ca", caCertificate) // エイリアス "ca" で証明書を追加
-
-                // そのキーストアを使用するTrustManagerを作成
-                val tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm()
-                val trustManagerFactory = TrustManagerFactory.getInstance(tmfAlgorithm)
-                trustManagerFactory.init(keyStore) // カスタムキーストアで初期化
-
-                val trustManagers = trustManagerFactory.trustManagers
-                val x509TrustManagers = trustManagers.filterIsInstance<X509TrustManager>()
-                if (x509TrustManagers.isEmpty()) {
-                    // 予期しない TrustManager が返された場合はログを出力し、カスタムの SSLSocketFactory を使用しない
-                    SoraLogger.w(TAG, "No X509TrustManager found in trust managers: ${trustManagers.contentToString()}")
-                    SoraLogger.w(TAG, "Falling back to default SSL context due to missing X509TrustManager.")
-                } else {
-                    if (x509TrustManagers.size > 1) {
-                        SoraLogger.w(TAG, "Multiple X509TrustManagers found. Using the first one.")
-                    }
-                    val trustManager = x509TrustManagers[0]
+                val customX509TrustManagerBuilder = CustomX509TrustManagerBuilder(caCertificate)
+                try {
+                    // カスタムTrustManagerを作成
+                    val trustManager = customX509TrustManagerBuilder.build()
 
                     // カスタムTrustManagerを使用するSSLContextを作成
                     val sslContext = SSLContext.getInstance("TLS")
                     sslContext.init(null, arrayOf(trustManager), null) // KeyManagerはnull、TrustManagerはカスタムのものを指定
                     builder = builder.sslSocketFactory(sslContext.socketFactory, trustManager)
+                } catch (e: Exception) {
+                    SoraLogger.w(TAG, "Failed to create custom X509TrustManager", e)
                 }
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -107,6 +107,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
                     sslContext.init(null, arrayOf(trustManager), null) // KeyManagerはnull、TrustManagerはカスタムのものを指定
                     builder = builder.sslSocketFactory(sslContext.socketFactory, trustManager)
                 } catch (e: Exception) {
+                    // カスタム TrustManager の作成に失敗した場合は、警告ログだけ出力して何もしないようにするため、Exception をキャッチする
                     SoraLogger.w(TAG, "Failed to create custom X509TrustManager", e)
                 }
             }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -35,6 +35,7 @@ class CustomX509TrustManagerBuilder(
         }
 
         // X509TrustManager を取り出す
+        // 万が一、X509TrustManager が見つからない場合は、NoSuchElementException がスローされる
         return trustManagerFactory.trustManagers
             .filterIsInstance<X509TrustManager>()
             .first()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -1,0 +1,42 @@
+package jp.shiguredo.sora.sdk.tls
+
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * CustomTrustManagerBuilder は、指定の CA 証明書を使用して TLS 接続を行うための
+ * カスタムされた TrustManager を構築するためのクラスです。
+ */
+class CustomX509TrustManagerBuilder(
+    /**
+     * CA 証明書を指定します。
+     */
+    private val caCertificate: X509Certificate
+) {
+    /**
+     * CA 証明書を使用して TLS 接続を行うためのカスタムされた TrustManager を構築します。
+     *
+     * @return 指定された CA 証明書を使用する X509TrustManager
+     */
+    fun build(): X509TrustManager {
+        // 空の KeyStore を用意し、指定された CA 証明書を登録
+        val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+            load(null, null)
+            setCertificateEntry("custom_ca", caCertificate)
+        }
+
+        // keyStore を使用して TrustManagerFactory を初期化
+        val trustManagerFactory = TrustManagerFactory.getInstance(
+            TrustManagerFactory.getDefaultAlgorithm()
+        ).apply {
+            init(keyStore)
+        }
+
+        // X509TrustManager を取り出す
+        return trustManagerFactory.trustManagers
+            .filterIsInstance<X509TrustManager>()
+            .first()
+    }
+}


### PR DESCRIPTION
X509TrustManager の生成する処理を OkHttp (WSS) 向けと libwebrtc (TURN-TLS) 向けとで共通化するために新たにクラスを作成しました。

動作に変更がないことはローカルで確認しています。
