### PR TITLE
insecure オプションを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,7 @@
 - [UPDATE] `SoraMediaChannel.Listener` の `onClose(SoraMediaChannel)` を非推奨に変更する
   - 今後は `onClose(SoraMediaChannel, SoraCloseEvent?)` を利用してもらう
   - @zztkm
-- [UPDATE] CA 証明書を指定できるようにする
+- [ADD] CA 証明書を指定できるようにする
   - この証明書は以下のタイミングで利用される
     - WebSocket シグナリング利用時
     - TURN-TLS 利用時
@@ -76,6 +76,10 @@
   - `SoraMediaChannel` で CA 証明書を指定しない場合のデフォルトの動作は以下
     - WebSocket シグナリングは OkHttp によりシステムのデフォルトが利用される
     - TURN-TLS は libwebrtc に内蔵されている証明書が利用される
+  - @zztkm
+- [ADD] サーバー証明書の検証を無効化できる ``insecure`` を ``SoraMediaChannel`` に追加する
+  - `true` に設定した場合、サーバー証明書の検証を行わない
+  - デフォルト値は ``false``
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -73,6 +73,7 @@ import kotlin.concurrent.schedule
  * @param forwardingFilterOption 転送フィルター機能の設定
  * @param forwardingFiltersOption リスト形式の転送フィルター機能の設定
  * @param caCertificate Sora との接続に利用する CA 証明書
+ * @param insecure Sora との接続時にすべての証明書を信頼するかどうかを決めるフラグ。開発時以外の利用は推奨しない。
  */
 class SoraMediaChannel @JvmOverloads constructor(
     private val context: Context,
@@ -101,6 +102,7 @@ class SoraMediaChannel @JvmOverloads constructor(
     // - https://developer.android.com/reference/kotlin/java/security/cert/Certificate
     // - https://developer.android.com/reference/kotlin/java/security/cert/X509Certificate
     private val caCertificate: X509Certificate? = null,
+    private val insecure: Boolean = false,
 ) {
     companion object {
         private val TAG = SoraMediaChannel::class.simpleName
@@ -738,6 +740,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             mediaOption = mediaOption,
             listener = null,
             caCertificate = caCertificate,
+            insecure = insecure,
         )
         clientOfferPeer.run {
             val subscription = requestClientOfferSdp()
@@ -794,6 +797,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             forwardingFilterOption = forwardingFilterOption,
             forwardingFiltersOption = forwardingFiltersOption,
             caCertificate = caCertificate,
+            insecure = insecure,
         )
         signaling!!.connect()
     }
@@ -813,6 +817,7 @@ class SoraMediaChannel @JvmOverloads constructor(
             dataChannelConfigs = offerMessage.dataChannels,
             listener = peerListener,
             caCertificate = caCertificate,
+            insecure = insecure,
         )
 
         if (offerMessage.dataChannels?.isNotEmpty() == true) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -474,6 +474,8 @@ class PeerChannelImpl(
         SoraLogger.d(TAG, "createPeerConnection")
         val dependenciesBuilder = PeerConnectionDependencies.builder(connectionObserver)
 
+        // CA 証明書が指定されいる、または insecure が true の場合は
+        // CustomSSLCertificateVerifier を設定する
         if (caCertificate != null || insecure) {
             try {
                 // CustomSSLCertificateVerifier の初期化

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -86,6 +86,7 @@ class PeerChannelImpl(
     private var listener: PeerChannel.Listener?,
     private var useTracer: Boolean = false,
     private val caCertificate: X509Certificate? = null,
+    private val insecure: Boolean = false,
 ) : PeerChannel {
 
     companion object {
@@ -473,11 +474,11 @@ class PeerChannelImpl(
         SoraLogger.d(TAG, "createPeerConnection")
         val dependenciesBuilder = PeerConnectionDependencies.builder(connectionObserver)
 
-        if (caCertificate != null) {
+        if (caCertificate != null || insecure) {
             try {
                 // CustomSSLCertificateVerifier の初期化
                 // 初期化時点で、CA 証明書の有効期限を確認するため、例外がスローされる可能性がある
-                dependenciesBuilder.setSSLCertificateVerifier(CustomSSLCertificateVerifier(caCertificate))
+                dependenciesBuilder.setSSLCertificateVerifier(CustomSSLCertificateVerifier(caCertificate, insecure))
             } catch (e: Exception) {
                 // CustomSSLCertificateVerifier の初期化に失敗した場合はログを出力して
                 // カスタムのサーバー証明書検証処理を設定しない

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
@@ -11,11 +11,13 @@ import javax.net.ssl.X509TrustManager
  * TURN-TLS のサーバ証明書を、指定した CA 証明書で検証する Verifier。
  *
  * @param caCertificate   X.509 形式 (PEM / DER どちらでも可) の CA 証明書
+ * @param insecure        すべての証明書を信頼するかどうか
  *
  * @throws NoSuchElementException 初期化時に X509TrustManager が取得できなかった場合
  */
 class CustomSSLCertificateVerifier(
-    private val caCertificate: X509Certificate
+    private val caCertificate: X509Certificate? = null,
+    private val insecure: Boolean = false,
 ) : SSLCertificateVerifier {
 
     companion object {
@@ -24,14 +26,37 @@ class CustomSSLCertificateVerifier(
 
     /**
      * コンストラクタ実行時に TrustManager を生成して保持しておく。
+     * insecure が true の場合は、null にする。
      *
      * CustomSSLCertificateVerifier の build は例外をスローする可能性があるため、
      * CustomSSLCertificateVerifier のインスタンスを生成する際に、例外処理を行う。
      */
-    private val trustManager: X509TrustManager =
-        CustomX509TrustManagerBuilder(caCertificate).build()
+    private val trustManager: X509TrustManager?
+
+    init {
+        if (caCertificate == null && !insecure) {
+            throw IllegalArgumentException("caCertificate is null and insecure is false")
+        }
+
+        if (insecure) {
+            SoraLogger.i(TAG, "insecure is true. all certificates are trusted")
+        }
+
+        trustManager = if (caCertificate != null) {
+            CustomX509TrustManagerBuilder(caCertificate).build()
+        } else {
+            null
+        }
+    }
 
     override fun verify(cert: ByteArray?): Boolean {
+
+        if (insecure) {
+            // insecure が true の場合は、すべての証明書を信頼する
+            SoraLogger.d(TAG, "verify return true. because insecure is true")
+            return true
+        }
+
         // TODO(zztkm): caCertificate がユーザー指定されていない場合は、OS の CA 証明書を使うように実装する
         // 例 LetsEncrypt の証明書を検証する場合など
         if (cert == null) {
@@ -48,7 +73,7 @@ class CustomSSLCertificateVerifier(
             serverCert.checkValidity()
 
             // チェーン検証
-            trustManager.checkServerTrusted(
+            trustManager?.checkServerTrusted(
                 arrayOf(serverCert),
                 serverCert.publicKey.algorithm
             )

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomSSLCertificateVerifier.kt
@@ -8,7 +8,8 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.X509TrustManager
 
 /**
- * TURN-TLS のサーバ証明書を、指定した CA 証明書で検証する Verifier。
+ * CA 証明書が指定された場合には TURN-TLS のサーバ証明書をその CA 証明書で検証し、
+ * insecure が true の場合にはすべての証明書を信頼する Verifier。
  *
  * @param caCertificate   X.509 形式 (PEM / DER どちらでも可) の CA 証明書
  * @param insecure        すべての証明書を信頼するかどうか

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -17,6 +17,23 @@ class CustomX509TrustManagerBuilder(
      */
     private val caCertificate: X509Certificate,
 ) {
+    companion object {
+        /**
+         * すべての証明書を信頼するTrustManagerを生成します。
+         * 開発環境やテスト環境でのみ使用してください。
+         *
+         * @return すべての証明書を信頼するX509TrustManager
+         */
+        @JvmStatic
+        fun createInsecureTrustManager(): X509TrustManager {
+            return object : X509TrustManager {
+                override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+                override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+                override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+            }
+        }
+    }
+
     /**
      * CA 証明書を使用して TLS 接続を行うためのカスタムされた TrustManager を構築します。
      *

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -16,13 +16,6 @@ class CustomX509TrustManagerBuilder(
      * CA 証明書を指定します。
      */
     private val caCertificate: X509Certificate,
-
-    /**
-     * すべての証明書を信頼するかどうかを指定します。
-     *
-     * デフォルトは false です。
-     */
-    private val insecure: Boolean = false,
 ) {
     /**
      * CA 証明書を使用して TLS 接続を行うためのカスタムされた TrustManager を構築します。
@@ -34,14 +27,6 @@ class CustomX509TrustManagerBuilder(
      * @throws NoSuchElementException X509TrustManager が取得できなかった場合
      */
     fun build(): X509TrustManager {
-        // insecure が true の場合、すべての証明書を信頼する TrustManager を返す
-        if (insecure) {
-             return object : X509TrustManager {
-                override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
-                override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
-                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-            }
-        }
 
         // CA 証明書の有効期限を確認
         caCertificate.checkValidity()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -13,7 +13,14 @@ class CustomX509TrustManagerBuilder(
     /**
      * CA 証明書を指定します。
      */
-    private val caCertificate: X509Certificate
+    private val caCertificate: X509Certificate,
+
+    /**
+     * すべての証明書を信頼するかどうかを指定します。
+     *
+     * デフォルトは false です。
+     */
+    private val insecure: Boolean = false,
 ) {
     /**
      * CA 証明書を使用して TLS 接続を行うためのカスタムされた TrustManager を構築します。
@@ -21,6 +28,15 @@ class CustomX509TrustManagerBuilder(
      * @return 指定された CA 証明書を使用する X509TrustManager
      */
     fun build(): X509TrustManager {
+        // insecure が true の場合、すべての証明書を信頼する TrustManager を返す
+        if (insecure) {
+             return object : X509TrustManager {
+                override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+                override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            }
+        }
+
         // 空の KeyStore を用意し、指定された CA 証明書を登録
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
             load(null, null)

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -15,7 +15,7 @@ class CustomX509TrustManagerBuilder(
     /**
      * CA 証明書を指定します。
      */
-    private val caCertificate: X509Certificate,
+    private val caCertificate: X509Certificate
 ) {
     companion object {
         /**


### PR DESCRIPTION
- [ADD] サーバー証明書の検証を無効化できる ``insecure`` を ``SoraMediaChannel`` に追加する
  - `true` に設定した場合、サーバー証明書の検証を行わない
  - デフォルト値は ``false``