### PR TITLE
CA 証明書の有効期限チェックが漏れていたため追加する

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/PeerChannel.kt
@@ -475,6 +475,8 @@ class PeerChannelImpl(
 
         if (caCertificate != null) {
             try {
+                // CustomSSLCertificateVerifier の初期化
+                // 初期化時点で、CA 証明書の有効期限を確認するため、例外がスローされる可能性がある
                 dependenciesBuilder.setSSLCertificateVerifier(CustomSSLCertificateVerifier(caCertificate))
             } catch (e: Exception) {
                 // CustomSSLCertificateVerifier の初期化に失敗した場合はログを出力して

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -99,6 +99,9 @@ class SignalingChannelImpl @JvmOverloads constructor(
             if (caCertificate != null) {
                 val customX509TrustManagerBuilder = CustomX509TrustManagerBuilder(caCertificate)
                 try {
+                    // NOTE: OkHttp で信頼する CA をカスタムする実装は以下の OkHttp のドキュメントを参考にした
+                    // https://square.github.io/okhttp/features/https/#customizing-trusted-certificates-kt-java
+
                     // カスタムTrustManagerを作成
                     // build() は CA 証明書の有効期限を確認するため、例外がスローされる可能性がある
                     val trustManager = customX509TrustManagerBuilder.build()
@@ -109,7 +112,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
                     builder = builder.sslSocketFactory(sslContext.socketFactory, trustManager)
                 } catch (e: Exception) {
                     // カスタム TrustManager の作成に失敗した場合は、警告ログだけ出力して何もしないようにするため、Exception をキャッチする
-                    SoraLogger.w(TAG, "Failed to create custom X509TrustManager", e)
+                    SoraLogger.w(TAG, "skip setting customizing trusted certificate", e)
                 }
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/signaling/SignalingChannel.kt
@@ -100,6 +100,7 @@ class SignalingChannelImpl @JvmOverloads constructor(
                 val customX509TrustManagerBuilder = CustomX509TrustManagerBuilder(caCertificate)
                 try {
                     // カスタムTrustManagerを作成
+                    // build() は CA 証明書の有効期限を確認するため、例外がスローされる可能性がある
                     val trustManager = customX509TrustManagerBuilder.build()
 
                     // カスタムTrustManagerを使用するSSLContextを作成

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -1,9 +1,9 @@
 package jp.shiguredo.sora.sdk.tls
 
 import java.security.KeyStore
-import java.security.cert.X509Certificate
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
+import java.security.cert.X509Certificate
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -2,6 +2,8 @@ package jp.shiguredo.sora.sdk.tls
 
 import java.security.KeyStore
 import java.security.cert.X509Certificate
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateNotYetValidException
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
@@ -19,6 +21,10 @@ class CustomX509TrustManagerBuilder(
      * CA 証明書を使用して TLS 接続を行うためのカスタムされた TrustManager を構築します。
      *
      * @return 指定された CA 証明書を使用する X509TrustManager
+     *
+     * @throws CertificateExpiredException CA 証明書の有効期限が切れている場合
+     * @throws CertificateNotYetValidException CA 証明書がまだ有効でない場合
+     * @throws NoSuchElementException X509TrustManager が取得できなかった場合
      */
     fun build(): X509TrustManager {
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/tls/CustomX509TrustManagerBuilder.kt
@@ -21,6 +21,10 @@ class CustomX509TrustManagerBuilder(
      * @return 指定された CA 証明書を使用する X509TrustManager
      */
     fun build(): X509TrustManager {
+
+        // CA 証明書の有効期限を確認
+        caCertificate.checkValidity()
+
         // 空の KeyStore を用意し、指定された CA 証明書を登録
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
             load(null, null)


### PR DESCRIPTION
CA Cert を指定した場合に、CA 自体の有効期限チェックが入ってなかったため、追加しました。