### PR TITLE
クライアントからの切断時に SoraCloseEvent に code: 1000, reason: NO-ERROR をいれる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
   - Sora から切断されたときに通知されるイベントである `SoraCloseEvent` を追加した
   - WebSocket シグナリング切断時に通知されるイベントである `SignalingChannelCloseEvent` を追加した
   - 以下の場合に、Sora から切断された際に `SoraCloseEvent` が通知される:
+    - `SoraMediaChannel.disconnect()` を呼び出した場合
     - WebSocket 経由のシグナリングを利用している場合
     - DataChannel 経由のシグナリングを利用する場合、かつ `ignore_disconnect_websocket` が true、かつ Sora の設定で `data_channel_signaling_close_message` が有効な場合
   - @zztkm

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseEvent.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraCloseEvent.kt
@@ -9,4 +9,23 @@ package jp.shiguredo.sora.sdk.channel
 data class SoraCloseEvent(
     val code: Int,
     val reason: String,
-)
+) {
+    companion object {
+        /**
+         * クライアントからの切断を表すステータスコード
+         */
+        const val CLIENT_DISCONNECT_CODE = 1000
+
+        /**
+         * クライアントからの切断を表す理由
+         */
+        const val CLIENT_DISCONNECT_REASON = "NO-ERROR"
+
+        /**
+         * クライアントからの切断用のSoraCloseEventインスタンスを生成
+         */
+        fun createClientDisconnectEvent(): SoraCloseEvent {
+            return SoraCloseEvent(CLIENT_DISCONNECT_CODE, CLIENT_DISCONNECT_REASON)
+        }
+    }
+}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -1013,7 +1013,8 @@ class SoraMediaChannel @JvmOverloads constructor(
      * アプリケーションとして切断後の処理が必要な場合は [Listener.onClose] で行います.
      */
     fun disconnect() {
-        // アプリケーションから切断された場合は NO-ERROR とする
+        // SoraMediaChannel.disconnect() 起因で internalDisconnect() を呼んだ場合、
+        // SoraCloseEvent は固定値として code: 1000, reason: "NO-ERROR" を設定する
         internalDisconnect(SoraDisconnectReason.NO_ERROR, SoraCloseEvent.createClientDisconnectEvent())
     }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -1014,7 +1014,7 @@ class SoraMediaChannel @JvmOverloads constructor(
      */
     fun disconnect() {
         // アプリケーションから切断された場合は NO-ERROR とする
-        internalDisconnect(SoraDisconnectReason.NO_ERROR, SoraCloseEvent(code = 1000, reason = "NO-ERROR"))
+        internalDisconnect(SoraDisconnectReason.NO_ERROR, SoraCloseEvent.createClientDisconnectEvent())
     }
 
     private fun internalDisconnect(disconnectReason: SoraDisconnectReason?, closeEvent: SoraCloseEvent? = null) {

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -1014,7 +1014,7 @@ class SoraMediaChannel @JvmOverloads constructor(
      */
     fun disconnect() {
         // アプリケーションから切断された場合は NO-ERROR とする
-        internalDisconnect(SoraDisconnectReason.NO_ERROR)
+        internalDisconnect(SoraDisconnectReason.NO_ERROR, SoraCloseEvent(code = 1000, reason = "NO-ERROR"))
     }
 
     private fun internalDisconnect(disconnectReason: SoraDisconnectReason?, closeEvent: SoraCloseEvent? = null) {


### PR DESCRIPTION
`SoraMediaChannel.disconnect()` を呼び出した場合にも、SoraCloseEvent を返すように変更する