### PR TITLE
AGP, targetSdkVersion, 依存ライブラリのアップデート

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,17 @@
 - [UPDATE] `SoraMediaChannel.Listener` の `onClose(SoraMediaChannel)` を非推奨に変更する
   - 今後は `onClose(SoraMediaChannel, SoraCloseEvent)` を利用してもらう
   - @zztkm
+- [UPDATE] compileSdkVersion と targetSdkVersion を 36 に上げる
+  - @miosakuma
+- [UPDATE] Android Gradle Plugin (AGP) を 8.10.1 にアップグレードする
+  - ビルドに利用される Gradle を 8.11.1 に上げる
+  - @miosakuma
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.google.code.gson:gson を 2.13.1 に上げる
+  - org.ajoberstar.grgit:grgit-gradle を 5.3.2 に上げる
+  - org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.9.0 に上げる
+  - org.robolectric:robolectric を 4.15.1 に上げる
+  - @miosakuma
 - [ADD] CA 証明書を指定できるようにする
   - この証明書は以下のタイミングで利用される
     - WebSocket シグナリング利用時

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,7 @@
   - ビルドに利用される Gradle を 8.11.1 に上げる
   - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
+  - org.jetbrains.dokka:dokka-gradle-plugin を 1.9.20 に上げる
   - com.google.code.gson:gson を 2.13.1 に上げる
   - org.ajoberstar.grgit:grgit-gradle を 5.3.2 に上げる
   - org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.9.0 に上げる

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.10.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
-        classpath 'org.ajoberstar.grgit:grgit-gradle:5.2.0'
+        classpath 'org.ajoberstar.grgit:grgit-gradle:5.3.2'
 
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.46.0"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.kotlin_version = '1.9.25'
     ext.libwebrtc_version = '136.7103.0.0'
 
-    ext.dokka_version = '1.8.10'
+    ext.dokka_version = '1.9.20'
 
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     // required by "signaling" part
     implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    // kotlinx.coroutines require kotlin 2.1.0
+    // kotlinx.coroutines requires kotlin 2.1.0
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 
     // required by "rtc" part

--- a/sora-android-sdk/build.gradle
+++ b/sora-android-sdk/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'org.jlleitschuh.gradle.ktlint'
 group = 'com.github.shiguredo'
 
 android {
-    compileSdkVersion 34
+    compileSdk 36
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
 
         buildConfigField("String", "REVISION", "\"${grgit.head().abbreviatedId}\"")
         buildConfigField("String", "LIBWEBRTC_VERSION", "\"${libwebrtc_version}\"")
@@ -94,9 +94,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
     // required by "signaling" part
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
+    // kotlinx.coroutines require kotlin 2.1.0
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 
     // required by "rtc" part
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
@@ -105,7 +106,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.6.1'
-    testImplementation('org.robolectric:robolectric:4.13') {
+    testImplementation('org.robolectric:robolectric:4.15.1') {
         exclude group: 'com.google.auto.service', module: 'auto-service'
     }
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"


### PR DESCRIPTION
Pull Request Overview の通りです。

補足としては

- Android Gradle Plugin (AGP) を 8.10.1 にアップグレードする
  - 8.11.x が最新ですがリリースが直近 2025/06/24 の Narwhal 2025.1.1 なので一つ落としています
- org.jetbrains.kotlinx:kotlinx-coroutines-android を 1.9.0 に上げる
  - 1.10.0 から Kotlin 2 系にする必要があるため、1.9.0 にしています。これはコメントにも記載しています。
- org.jetbrains.dokka:dokka-gradle-plugin を 1.9.20 に上げる
  - ドキュメントが出力されることを確認しています

---
This pull request updates the Android project to use newer SDK versions, upgrades Gradle and its dependencies, and updates various libraries to their latest versions for improved compatibility and functionality.

### SDK and Build Tool Updates:
* Updated `compileSdkVersion` and `targetSdkVersion` to 36 in `sora-android-sdk/build.gradle`.
* Upgraded Android Gradle Plugin (AGP) to 8.10.1 and Gradle to 8.11.1 in `gradle-wrapper.properties`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R72-R82) [[2]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3)

### Dependency Updates:
* Upgraded `com.google.code.gson:gson` to version 2.13.1 in `sora-android-sdk/build.gradle`.
* Updated `org.jetbrains.kotlinx:kotlinx-coroutines-android` to version 1.9.0, requiring Kotlin 2.1.0.
* Upgraded `org.robolectric:robolectric` to version 4.15.1 in `sora-android-sdk/build.gradle`.