### PR TITLE
libwebrtc を 138.7204.0.2 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,8 +41,8 @@
   - String にはエラーの詳細情報を設定する
     - 詳細がない場合は空文字列を設定する
   - @zztkm
-- [UPDATE] libwebrtc を 136.7103.0.0 に上げる
-  - @zztkm
+- [UPDATE] libwebrtc を 138.7204.0.2 に上げる
+  - @zztkm @miosakuma
 - [UPDATE] `SoraMediaOption.enableMultistream` を非推奨にする
   - @zztkm
 - [UPDATE] `SoraMediaOption` に `enableLegacyStream` を追加する

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.libwebrtc_version = '136.7103.0.0'
+    ext.libwebrtc_version = '138.7204.0.2'
 
     ext.dokka_version = '1.9.20'
 


### PR DESCRIPTION
- [UPDATE] libwebrtc を 138.7204.0.2 に上げる

---

This pull request updates the `CHANGES.md` file to reflect changes in library versions and feature deprecations. The most notable change is the update to the `libwebrtc` library version.

Library version updates:

* Updated `libwebrtc` from version `136.7103.0.0` to `138.7204.0.2`.