### PR TITLE
Kotlin バージョンを 2.0.20 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] Kotlin バージョンを 2.0.20 に上げる
+  - @t-miya
+
 ### misc
 
 - [UPDATE] Android Gradle Plugin バージョンを 8.11.1 に上げる

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Build tools
 android-gradle-plugin = "8.11.1"
-kotlin = "1.9.25"
+kotlin = "2.0.20"
 dokka = "1.9.20"
 ktlint-gradle = "11.3.1"
 grgit = "5.3.2"

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -44,7 +44,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
                 Callable {
                     SoraLogger.i(
                         TAG,
-                        """initEncode() thread=${Thread.currentThread().name} [${Thread.currentThread().id}]
+                        """initEncode() thread=${Thread.currentThread().name} [tid=${android.os.Process.myTid()}]
                 |  encoder=${encoder.implementationName}
                 |  streamSettings:
                 |    numberOfCores=${settings.numberOfCores}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt
@@ -33,6 +33,15 @@ internal class SimulcastVideoEncoderFactoryWrapper(
             val TAG = StreamEncoderWrapper::class.simpleName
         }
 
+        private fun currentThreadIdForLog(): Long {
+            return if (android.os.Build.VERSION.SDK_INT >= 36) {
+                Thread.currentThread().threadId()
+            } else {
+                @Suppress("DEPRECATION")
+                Thread.currentThread().id
+            }
+        }
+
         // 単一スレッドで実行するための ExecutorService
         // 中にあるスレッドが終了しない限りは、つねに同じスレッド上で実行されることが保証されている。
         val executor: ExecutorService = Executors.newSingleThreadExecutor()
@@ -44,7 +53,7 @@ internal class SimulcastVideoEncoderFactoryWrapper(
                 Callable {
                     SoraLogger.i(
                         TAG,
-                        """initEncode() thread=${Thread.currentThread().name} [tid=${android.os.Process.myTid()}]
+                        """initEncode() thread=${Thread.currentThread().name} [tid=${currentThreadIdForLog()}]
                 |  encoder=${encoder.implementationName}
                 |  streamSettings:
                 |    numberOfCores=${settings.numberOfCores}

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/ZipHelper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/ZipHelper.kt
@@ -26,13 +26,21 @@ class ZipHelper {
         }
 
         override fun read(bytes: ByteArray, off: Int, len: Int): Int {
-            var len = len
+            // Java からの呼び出し時の安全性確保（null と範囲チェック）
+            val dst = (bytes as ByteArray?)
+                ?: throw NullPointerException("bytes must not be null")
+
+            if (off < 0 || len < 0 || off > dst.size || len > dst.size - off) {
+                throw IndexOutOfBoundsException("off=$off, len=$len, size=${dst.size}")
+            }
+
             if (!buf.hasRemaining()) {
                 return -1
             }
-            len = Math.min(len, buf.remaining())
-            buf.get(bytes, off, len)
-            return len
+
+            val toRead = minOf(len, buf.remaining())
+            buf.get(dst, off, toRead)
+            return toRead
         }
     }
 }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/ZipHelper.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/ZipHelper.kt
@@ -25,7 +25,7 @@ class ZipHelper {
             }
         }
 
-        override fun read(bytes: ByteArray?, off: Int, len: Int): Int {
+        override fun read(bytes: ByteArray, off: Int, len: Int): Int {
             var len = len
             if (!buf.hasRemaining()) {
                 return -1


### PR DESCRIPTION
ソースコード修正は lint 警告対応
```
▌w: file:///sora-android-sdk/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/codec/SimulcastVideoEncoderFactoryWrapper.kt:47:105 'val id: Long' is deprecated. Deprecated in Java.
▌w: file:///sora-android-sdk/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/util/ZipHelper.kt:34:21 Java type mismatch: inferred type is 'kotlin.ByteArray?', but 'kotlin.ByteArray' was expected.
```