### PR TITLE
capturer.stopCapture を SurfaceTextureHelper.dispose() より前に呼ぶようにする

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
@@ -52,21 +52,23 @@ class RTCLocalVideoManager(
     fun dispose() {
         SoraLogger.d(TAG, "dispose")
         if (isOwnedCapturer) {
-            SoraLogger.d(TAG, "stop owned capturer")
+            SoraLogger.d(TAG, "dispose owned VideoCapturer")
             /*
-                CameraCapturer.stopCapture() は SurfaceTextureHelper.dispose() より先に呼ぶ理由。
+              CameraCapturer.dispose() を SurfaceTextureHelper.dispose() より先に呼ぶ理由。
 
-                CameraCapturer は initialize() で SurfaceTextureHelper から Handler を受け取り、
-                cameraThreadHandler にセットしている。
-                SurfaceTextureHelper.dispose() を呼ぶと handler.getLooper().quit() が呼ばれ、
-                Handler に関連付いた Looper が終了する。
+              CameraCapturer は initialize() で SurfaceTextureHelper から
+              android.os.Handler を受け取り、cameraThreadHandler にセットしている。
 
-                CameraCapturer.stopCapture() は内部で cameraThreadHandler.post() を呼ぶが、
-                もし SurfaceTextureHelper.dispose() を先に呼んでしまうと、
-                stopCapture() 時点で Looper が終了済みのため、cameraThreadHandler.post() の
-                メッセージ送信に失敗し、MessageQueue の warning ログが出力されてしまう。
+              SurfaceTextureHelper.dispose() を呼ぶと handler.getLooper().quit() が呼ばれ、
+              Handler に関連付いた Looper が終了する。
+
+              CameraCapturer.dispose() (stopCapture() を呼ぶだけ) は内部で cameraThreadHandler.post() を呼ぶが、
+              事前に SurfaceTextureHelper.dispose() を呼んでいた場合、
+              stopCapture() 時点で cameraThreadHandler に関連付く Looper が終了済みのため、cameraThreadHandler.post() の
+              メッセージ送信に失敗し、warning ログが出力されてしまう。
+              これを防ぐために、。CameraCapturer.dispose() を先に呼ぶ。
              */
-            capturer.stopCapture()
+            capturer.dispose()
         }
 
         SoraLogger.d(TAG, "dispose surfaceTextureHelper")

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
@@ -66,7 +66,7 @@ class RTCLocalVideoManager(
               事前に SurfaceTextureHelper.dispose() を呼んでいた場合、
               stopCapture() 時点で cameraThreadHandler に関連付く Looper が終了済みのため、cameraThreadHandler.post() の
               メッセージ送信に失敗し、warning ログが出力されてしまう。
-              これを防ぐために、。CameraCapturer.dispose() を先に呼ぶ。
+              これを防ぐために、CameraCapturer.dispose() を先に呼ぶ。
              */
             capturer.dispose()
         }

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
@@ -60,12 +60,11 @@ class RTCLocalVideoManager(
               android.os.Handler を受け取り、cameraThreadHandler にセットしている。
 
               SurfaceTextureHelper.dispose() を呼ぶと handler.getLooper().quit() が呼ばれ、
-              Handler に関連付いた Looper が終了する。
+              cameraThreadHandler に関連付いた Looper が終了する。
 
               CameraCapturer.dispose() (stopCapture() を呼ぶだけ) は内部で cameraThreadHandler.post() を呼ぶが、
-              事前に SurfaceTextureHelper.dispose() を呼んでいた場合、
-              stopCapture() 時点で cameraThreadHandler に関連付く Looper が終了済みのため、cameraThreadHandler.post() の
-              メッセージ送信に失敗し、warning ログが出力されてしまう。
+              先に SurfaceTextureHelper.dispose() を呼んでいた場合、 cameraThreadHandler に関連付く Looper が終了済みのため
+              cameraThreadHandler.post() が失敗し、warning ログが出力されてしまう。
               これを防ぐために、CameraCapturer.dispose() を先に呼ぶ。
              */
             capturer.dispose()

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCLocalVideoManager.kt
@@ -51,17 +51,30 @@ class RTCLocalVideoManager(
 
     fun dispose() {
         SoraLogger.d(TAG, "dispose")
+        if (isOwnedCapturer) {
+            SoraLogger.d(TAG, "stop owned capturer")
+            /*
+                CameraCapturer.stopCapture() は SurfaceTextureHelper.dispose() より先に呼ぶ理由。
+
+                CameraCapturer は initialize() で SurfaceTextureHelper から Handler を受け取り、
+                cameraThreadHandler にセットしている。
+                SurfaceTextureHelper.dispose() を呼ぶと handler.getLooper().quit() が呼ばれ、
+                Handler に関連付いた Looper が終了する。
+
+                CameraCapturer.stopCapture() は内部で cameraThreadHandler.post() を呼ぶが、
+                もし SurfaceTextureHelper.dispose() を先に呼んでしまうと、
+                stopCapture() 時点で Looper が終了済みのため、cameraThreadHandler.post() の
+                メッセージ送信に失敗し、MessageQueue の warning ログが出力されてしまう。
+             */
+            capturer.stopCapture()
+        }
+
         SoraLogger.d(TAG, "dispose surfaceTextureHelper")
         surfaceTextureHelper?.dispose()
         surfaceTextureHelper = null
 
         SoraLogger.d(TAG, "dispose source")
         source?.dispose()
-
-        if (isOwnedCapturer) {
-            capturer.stopCapture()
-            capturer.dispose()
-        }
     }
 
     /**


### PR DESCRIPTION
#218 の修正