### PR TITLE
Slack 通知 job を分離し build job を ubuntu-24.04 へ変更する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -42,11 +42,16 @@ jobs:
         run: ./gradlew build
       - name: Lint Check
         run: ./gradlew ktlintCheck
+
+  slack_notify:
+    needs: [build]
+    runs-on: ubuntu-slim
+    if: always()
+    steps:
       - name: Slack Notification
-        if: always()
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: ${{ job.status }}
+          status: ${{ needs.build.result }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-android-sdk
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Slack Notification
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: ${{ needs.build.result }}
+          status: ${{ job.status }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-android-sdk
         env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,6 @@
 
 ## develop
 
-### misc
-
-- [CHANGES] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に変更する
-  - @voluntas
-- [CHANGES] GitHub Actions の runs-on を ubuntu-slim に変更する
-  - @voluntas
 - [UPDATE] libwebrtc を 144.7559.2.2 に上げる
   - @zztkm
 - [UPDATE] SoraMediaChannel.setAudioRecordingPaused を非推奨にする
@@ -79,6 +73,9 @@
 
 ### misc
 
+- [CHANGES] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に変更する
+  - slack-notify は build から別の job に移す
+  - @voluntas
 - [UPDATE] `Claude Assistant` の `claude-response` を `ubuntu-slim` に移行する
   - @zztkm
 - [UPDATE] .gitignore に Android Studio 関連の除外設定を追加する


### PR DESCRIPTION
## 変更内容
- build job の runs-on を ubuntu-slim から ubuntu-24.04 へ変更
- Slack Notification を build job の step から独立した slack_notify job に分離
- slack_notify job に needs と if: always() を設定し、build 結果を通知するように変更

参考: https://github.com/shiguredo/hisui/blob/develop/.github/workflows/ci.yml#L292-L318