### PR TITLE
[WIP] カメラモード切り替えなどの課題の修正

### DIFF
--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/SoraMediaChannel.kt
@@ -544,6 +544,11 @@ class SoraMediaChannel
                 SoraLogger.w(TAG, "Cannot call setVideoHardMute: videoCapturer is not controllable")
                 return false
             }
+            val localVideoManager =
+                peer?.localVideoManager ?: run {
+                    SoraLogger.w(TAG, "Cannot call setVideoHardMute: localVideoManager is not initialized")
+                    return false
+                }
             if (muted) {
                 // ハードミュートを有効化する場合は先にソフトミュートを行う
                 if (!setVideoSoftMute(true)) {
@@ -553,9 +558,9 @@ class SoraMediaChannel
             }
             return try {
                 if (muted) {
-                    peer?.localVideoManager?.stopVideoCapture()
+                    localVideoManager.stopVideoCapture()
                 } else {
-                    peer?.localVideoManager?.startVideoCapture()
+                    localVideoManager.startVideoCapture()
                 }
                 if (!muted) {
                     // ハードミュートを無効化する場合はハードミュート無効化後にソフトミュートを無効化する
@@ -578,11 +583,16 @@ class SoraMediaChannel
          * @return 成功した場合は true、失敗した場合は false
          */
         fun setVideoSoftMute(muted: Boolean): Boolean =
-            try {
-                peer?.localVideoManager?.setTrackEnabled(!muted)
-                true
-            } catch (e: Exception) {
-                SoraLogger.w(TAG, "Failed to setVideoSoftMute: ${e.message}")
+            peer?.localVideoManager?.let { localVideoManager ->
+                try {
+                    localVideoManager.setTrackEnabled(!muted)
+                    true
+                } catch (e: Exception) {
+                    SoraLogger.w(TAG, "Failed to setVideoSoftMute: ${e.message}")
+                    false
+                }
+            } ?: run {
+                SoraLogger.w(TAG, "Cannot call setVideoSoftMute: localVideoManager is not initialized")
                 false
             }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -171,6 +171,7 @@ class SoraMediaOption {
     fun enableSimulcast(rid: SoraVideoOption.SimulcastRid?) {
         simulcastEnabled = true
         simulcastRid = rid
+        simulcastRequestRid = null
     }
 
     /**
@@ -181,6 +182,7 @@ class SoraMediaOption {
     @JvmOverloads
     fun enableSimulcast(requestRid: SoraVideoOption.SimulcastRequestRid? = null) {
         simulcastEnabled = true
+        simulcastRid = null
         simulcastRequestRid = requestRid
     }
 

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraMediaOption.kt
@@ -153,6 +153,8 @@ class SoraMediaOption {
         cameraConfig: SoraCameraConfig,
     ) {
         videoUpstreamEnabled = true
+        // SDK 内部生成モードに切り替えるため、過去のユーザー設定 capturer を明示的に解除する
+        videoCapturer = null
         videoUpstreamContext = eglContext
         soraCameraConfig = cameraConfig
     }


### PR DESCRIPTION
## 概要
- コードレビューで指摘された 3 件の問題を修正する

## 変更内容
- SDK 内部カメラモードへ切り替える際に、過去に設定された `videoCapturer` を明示的に解除する
- `enableSimulcast(rid)` と `enableSimulcast(requestRid)` を相互排他にし、両方のパラメータが同時送信されないようにする
- `setVideoHardMute` / `setVideoSoftMute` で `localVideoManager` 未初期化時に `false` を返すようにし、誤った成功判定を防ぐ

## 確認
- `./gradlew :sora-android-sdk:test`
