### PR TITLE
(WIP)AudioSource に UNPROCESSED を設定できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] SoraAudioOption に `useUnprocessedAudioSource` プロパティを追加する
+  - true の場合、SDK 内部で生成する AudioDeviceModule の音声入力ソースに `MediaRecorder.AudioSource.UNPROCESSED` を利用する
+  - API 24 未満では `UNPROCESSED` を利用できないため、SDK 側で `MediaRecorder.AudioSource.VOICE_COMMUNICATION` にフォールバックする
+
 - [ADD] SoraMediaChannel.Listener に onSignalingMessage を追加する
   - WebSocket と DataChannel (signaling label のみ) のシグナリングメッセージを JSON 文字列で取得できる
   - Sora JavaScript SDK に合わせるため、通知対象を `sora-js-sdk 2025.2.0` (commit: `9b76c0757cb213cc76a2e7387b24f4cd5eb73764`) の signaling callback と同じシグナリング項目にする

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/option/SoraAudioOption.kt
@@ -102,6 +102,18 @@ class SoraAudioOption {
     var audioSource: Int = MediaRecorder.AudioSource.VOICE_COMMUNICATION
 
     /**
+     * 音声入力に `android.media.MediaRecorder.AudioSource.UNPROCESSED` を使うかどうかのフラグ.
+     * `UNPROCESSED` 時は Android による音質調整が行われない未加工の音声による配信となります。
+     *
+     * true の場合、AudioDeviceModule 生成時に [audioSource] より優先して `UNPROCESSED` を利用します.
+     * ただし、API 24 未満では `UNPROCESSED` を利用できないため、SDK 側で
+     * `VOICE_COMMUNICATION` にフォールバックします.
+     *
+     * デフォルト値は false です.
+     */
+    var useUnprocessedAudioSource: Boolean = false
+
+    /**
      * 入力をステレオにするかどうかのフラグ.
      *
      * AudioDeviceModule 生成時に利用されます.

--- a/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
+++ b/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt
@@ -1,7 +1,10 @@
 package jp.shiguredo.sora.sdk.channel.rtc
 
 import android.content.Context
+import android.media.MediaRecorder
+import android.os.Build
 import jp.shiguredo.sora.sdk.camera.CameraCapturerFactory
+import jp.shiguredo.sora.sdk.channel.option.SoraAudioOption
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
 import jp.shiguredo.sora.sdk.codec.SimulcastVideoEncoderFactoryWrapper
 import jp.shiguredo.sora.sdk.codec.SoraDefaultVideoEncoderFactory
@@ -248,7 +251,7 @@ class RTCComponentFactory(
                     mediaOption.audioOption.useHardwareNoiseSuppressor,
             ).setAudioRecordErrorCallback(audioRecordErrorCallback)
             .setAudioTrackErrorCallback(audioTrackErrorCallback)
-            .setAudioSource(mediaOption.audioOption.audioSource)
+            .setAudioSource(resolveAudioSource(mediaOption.audioOption))
             .setUseStereoInput(mediaOption.audioOption.useStereoInput)
             .setUseStereoOutput(mediaOption.audioOption.useStereoOutput)
             .createAudioDeviceModule()
@@ -259,5 +262,20 @@ class RTCComponentFactory(
         errorMessage: String,
     ) {
         listener?.onError(errorReason, errorMessage)
+    }
+
+    // AudioSource の設定時、API レベルによっては使用できないためフォールバックするリゾルバー
+    internal fun resolveAudioSource(
+        audioOption: SoraAudioOption,
+        sdkInt: Int = Build.VERSION.SDK_INT,
+    ): Int {
+        if (!audioOption.useUnprocessedAudioSource) {
+            return audioOption.audioSource
+        }
+        if (sdkInt >= Build.VERSION_CODES.N) {
+            return MediaRecorder.AudioSource.UNPROCESSED
+        }
+        SoraLogger.w(TAG, "UNPROCESSED audio source is not supported on API $sdkInt, fallback to VOICE_COMMUNICATION")
+        return MediaRecorder.AudioSource.VOICE_COMMUNICATION
     }
 }


### PR DESCRIPTION
AudioDeviceModule 初期化時に、Android による音質調整をしない、`MediaRecorder.AudioSource.UNPROCESSED` 設定をできるようにする。
`UNPROCESSED` 設定には APIレベル24以上が必要なため、実行環境の APIレベルが24未満の場合 `VOICE_COMMUNICATION` にフォールバックする